### PR TITLE
Improved calendar

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -11,6 +11,7 @@
         "@fullcalendar/daygrid": "^6.1.17",
         "@fullcalendar/list": "^6.1.17",
         "@fullcalendar/react": "^6.1.17",
+        "@uidotdev/usehooks": "^2.4.1",
         "next": "15.3.1",
         "react": "^19.0.0",
         "react-dom": "^19.0.0"
@@ -1513,6 +1514,18 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@uidotdev/usehooks": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@uidotdev/usehooks/-/usehooks-2.4.1.tgz",
+      "integrity": "sha512-1I+RwWyS+kdv3Mv0Vmc+p0dPYH0DTRAo04HLyXReYBL9AeseDWUJyi4THuksBJcu9F0Pih69Ak150VDnqbVnXg==",
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "react": ">=18.0.0",
+        "react-dom": ">=18.0.0"
       }
     },
     "node_modules/@unrs/resolver-binding-darwin-arm64": {

--- a/web/package.json
+++ b/web/package.json
@@ -12,6 +12,7 @@
     "@fullcalendar/daygrid": "^6.1.17",
     "@fullcalendar/list": "^6.1.17",
     "@fullcalendar/react": "^6.1.17",
+    "@uidotdev/usehooks": "^2.4.1",
     "next": "15.3.1",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"

--- a/web/src/features/calendar/Agenda.tsx
+++ b/web/src/features/calendar/Agenda.tsx
@@ -3,7 +3,12 @@ import FullCalendar from "@fullcalendar/react";
 import listPlugin from "@fullcalendar/list";
 import type { Event } from "./event.d";
 
-export const Agenda = ({ events }: { events: Event[] }) => {
+type Props = {
+  events: Event[];
+  switchView: ()=>void;
+  isMobile: boolean;
+}
+export const Agenda = ({ events, switchView, isMobile }: Props) => {
   const calendarRef = useRef<FullCalendar>(null);
 
   const renderedEvents: FullCalendar["props"]["events"] = useMemo(() => {
@@ -25,13 +30,24 @@ export const Agenda = ({ events }: { events: Event[] }) => {
       plugins={[listPlugin]}
       initialView="listMonth"
       eventDisplay="block"
+      customButtons={{
+        switchView: {
+          text: 'View as calendar',
+          click: switchView
+        }
+      }}
+      headerToolbar={{
+        left: 'title',
+        center: '',
+        right: !isMobile? 'switchView prev,next' : 'today prev,next'
+      }}
       events={renderedEvents}
       eventContent={(eventInfo) => {
         const [title, description, image] = eventInfo.event.title.split("|||");
         return (
           <a href={eventInfo.event.url}>
             <div className="max-w-full text-lg bg-purple-400 text-gray-900 p-1">
-              <p>{title}</p>
+              <h3 className="font-semibold">{title}</h3>
               <p>{description}</p>
               {/* eslint-disable-next-line @next/next/no-img-element */}
               <img

--- a/web/src/features/calendar/Calendar.tsx
+++ b/web/src/features/calendar/Calendar.tsx
@@ -57,9 +57,8 @@ export const Calendar = ({ events, switchView, isMobile }: Props) => {
                 {eventInfo.timeText}
                 {name ? ` • ${tag}` : undefined }
               </p>
-              <p>
-                <h3 className="font-semibold text-wrap">{name? name : eventInfo.event.title}</h3>
-              </p>
+              <h3 className="font-semibold text-wrap">{name? name : eventInfo.event.title}</h3>
+              
               {/* eslint-disable-next-line @next/next/no-img-element */}
               <img
                 className="pointer-events-none"

--- a/web/src/pages/agenda.tsx
+++ b/web/src/pages/agenda.tsx
@@ -22,7 +22,7 @@ export const getStaticProps = (async () => {
 const EventAgendaPage = ({
   events,
 }: InferGetStaticPropsType<typeof getStaticProps>) => {
-  return <Agenda events={events} />;
+  return <Agenda isMobile={false} switchView={()=>{}} events={events} />;
 };
 
 export default EventAgendaPage;

--- a/web/src/pages/calendar.tsx
+++ b/web/src/pages/calendar.tsx
@@ -1,7 +1,9 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import type { InferGetStaticPropsType, GetStaticProps } from "next";
 import { Calendar } from "@/features/calendar/Calendar";
 import { Event } from "@/features/calendar/event";
+import { useWindowSize } from "@uidotdev/usehooks";
+import { Agenda } from "@/features/calendar/Agenda";
 
 async function getEvents() {
   const res = await fetch(
@@ -22,7 +24,25 @@ export const getStaticProps = (async () => {
 const EventCalendarPage = ({
   events,
 }: InferGetStaticPropsType<typeof getStaticProps>) => {
-  return <Calendar events={events} />;
+  const [viewType, setViewType] = useState<'calendar' | 'agenda'>('calendar');
+  const [isMobile, setMobile] = useState(false);
+  const {width} = useWindowSize();
+
+  useEffect(()=>{
+    if (width && width < 700) {
+      setMobile(true);
+      setViewType('agenda');
+    } else {
+      setMobile(false);
+    }
+  }, [width]);
+
+  return (
+    <div>
+      {viewType === 'calendar' && <Calendar events={events} isMobile={isMobile} switchView={()=>setViewType('agenda')}/>}
+      {viewType === 'agenda' && <Agenda events={events} isMobile={isMobile} switchView={()=>setViewType('calendar')}/>}
+    </div>
+  );
 };
 
 export default EventCalendarPage;

--- a/web/src/pages/calendar.tsx
+++ b/web/src/pages/calendar.tsx
@@ -31,7 +31,6 @@ const EventCalendarPage = ({
   useEffect(()=>{
     if (width && width < 700) {
       setMobile(true);
-      setViewType('agenda');
     } else {
       setMobile(false);
     }
@@ -39,8 +38,8 @@ const EventCalendarPage = ({
 
   return (
     <div>
-      {viewType === 'calendar' && <Calendar events={events} isMobile={isMobile} switchView={()=>setViewType('agenda')}/>}
-      {viewType === 'agenda' && <Agenda events={events} isMobile={isMobile} switchView={()=>setViewType('calendar')}/>}
+      {(!isMobile && viewType === 'calendar') && <Calendar events={events} isMobile={isMobile} switchView={()=>setViewType('agenda')}/>}
+      {(isMobile || viewType === 'agenda') && <Agenda events={events} isMobile={isMobile} switchView={()=>setViewType('calendar')}/>}
     </div>
   );
 };


### PR DESCRIPTION
Modified the calendar view to display as the agenda when in mobile, and added a button to switch between both modes in desktop. I also changed the name to be a h3 and made it a bit bolder and wrapping. Let me know if that is not wanted; I was just experimenting.

<img width="1113" alt="image" src="https://github.com/user-attachments/assets/62f73c75-fb5a-4559-8d14-df61fb283b59" />

<img width="1113" alt="image" src="https://github.com/user-attachments/assets/bcc7a491-26d2-406b-8b9e-78da88a6a762" />

<img width="577" alt="image" src="https://github.com/user-attachments/assets/7b18cb05-a01e-45c9-90af-5b05fd169576" />
