### PR TITLE
Refactor pages into features

### DIFF
--- a/administration/client/src/components/AddVolunteerForm.tsx
+++ b/administration/client/src/components/AddVolunteerForm.tsx
@@ -1,0 +1,212 @@
+import React, { useState } from 'react';
+import { CreateVolunteerRequest, Member } from '../types';
+
+const VOLUNTEER_ROLES = [
+  'coordinator',
+  'setup',
+  'greeter',
+  'tech',
+  'cleanup',
+  'registration',
+  'security',
+  'catering',
+  'av_support',
+  'photographer',
+];
+
+export const AddVolunteerForm = ({
+  members,
+  onAddVolunteer,
+  isLoading,
+  onCancel,
+}: {
+  members: Member[];
+  onAddVolunteer: (data: CreateVolunteerRequest) => Promise<void>;
+  isLoading?: boolean;
+  onCancel: () => void;
+}) => {
+  const [formData, setFormData] = useState<CreateVolunteerRequest>({
+    member_id: 0,
+    role: '',
+    contact_phone: '',
+    contact_email: '',
+    arrival_time: '',
+    departure_time: '',
+    special_instructions: '',
+    equipment_needed: [],
+    skills_required: [],
+    volunteer_notes: '',
+  });
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!formData.member_id || !formData.role) return;
+
+    await onAddVolunteer(formData);
+    setFormData({
+      member_id: 0,
+      role: '',
+      contact_phone: '',
+      contact_email: '',
+      arrival_time: '',
+      departure_time: '',
+      special_instructions: '',
+      equipment_needed: [],
+      skills_required: [],
+      volunteer_notes: '',
+    });
+  };
+
+  const handleChange = (field: keyof CreateVolunteerRequest, value: any) => {
+    setFormData((prev) => ({ ...prev, [field]: value }));
+  };
+
+  return (
+    <div className="pb-6">
+      <h3 className="text-lg font-medium mb-4">Add New Volunteer</h3>
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              Member *
+            </label>
+            <select
+              value={formData.member_id}
+              onChange={(e) =>
+                handleChange('member_id', parseInt(e.target.value))
+              }
+              className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+              required
+            >
+              <option value={0}>Select a member</option>
+              {members.map((member) => (
+                <option key={member.id} value={member.id}>
+                  {member.first_name} {member.last_name}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              Role *
+            </label>
+            <select
+              value={formData.role}
+              onChange={(e) => handleChange('role', e.target.value)}
+              className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+              required
+            >
+              <option value="">Select a role</option>
+              {VOLUNTEER_ROLES.map((role) => (
+                <option key={role} value={role}>
+                  {role
+                    .replace('_', ' ')
+                    .replace(/\b\w/g, (l) => l.toUpperCase())}
+                </option>
+              ))}
+            </select>
+          </div>
+        </div>
+
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              Contact Phone
+            </label>
+            <input
+              type="tel"
+              value={formData.contact_phone}
+              onChange={(e) => handleChange('contact_phone', e.target.value)}
+              className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+            />
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              Contact Email
+            </label>
+            <input
+              type="email"
+              value={formData.contact_email}
+              onChange={(e) => handleChange('contact_email', e.target.value)}
+              className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+            />
+          </div>
+        </div>
+
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              Arrival Time
+            </label>
+            <input
+              type="datetime-local"
+              value={formData.arrival_time}
+              onChange={(e) => handleChange('arrival_time', e.target.value)}
+              className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+            />
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              Departure Time
+            </label>
+            <input
+              type="datetime-local"
+              value={formData.departure_time}
+              onChange={(e) => handleChange('departure_time', e.target.value)}
+              className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+            />
+          </div>
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1">
+            Special Instructions
+          </label>
+          <textarea
+            value={formData.special_instructions}
+            onChange={(e) =>
+              handleChange('special_instructions', e.target.value)
+            }
+            rows={3}
+            className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+            placeholder="Any special instructions for this volunteer"
+          />
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1">
+            Volunteer Notes
+          </label>
+          <textarea
+            value={formData.volunteer_notes}
+            onChange={(e) => handleChange('volunteer_notes', e.target.value)}
+            rows={2}
+            className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+            placeholder="Notes from the volunteer"
+          />
+        </div>
+
+        <div className="flex justify-end gap-4 pt-4">
+          <button
+            type="button"
+            onClick={onCancel}
+            className="px-4 py-2 border border-gray-300 rounded-md text-gray-700 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-blue-500"
+            disabled={isLoading}
+          >
+            Cancel
+          </button>
+          <button
+            type="submit"
+            disabled={isLoading || !formData.member_id || !formData.role}
+            className="px-4 py-2 bg-blue-500 text-white rounded-md hover:bg-blue-600 focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:opacity-50"
+          >
+            {isLoading ? 'Adding...' : 'Add Volunteer'}
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+};

--- a/administration/client/src/components/EventVolunteersManager.tsx
+++ b/administration/client/src/components/EventVolunteersManager.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
-import { EventVolunteer, CreateVolunteerRequest, Member } from '../types';
+import { CreateVolunteerRequest, EventVolunteer, Member } from '../types';
+import { AddVolunteerForm } from './AddVolunteerForm';
 
 interface EventVolunteersManagerProps {
   eventId: number;
@@ -9,68 +10,19 @@ interface EventVolunteersManagerProps {
   isLoading?: boolean;
 }
 
-const VOLUNTEER_ROLES = [
-  'coordinator',
-  'setup',
-  'greeter', 
-  'tech',
-  'cleanup',
-  'registration',
-  'security',
-  'catering',
-  'av_support',
-  'photographer'
-];
+const getMemberName = (members: Member[], memberId: number) => {
+  const member = members.find((m) => m.id === memberId);
+  return member ? `${member.first_name} ${member.last_name}` : 'Unknown Member';
+};
 
 export const EventVolunteersManager: React.FC<EventVolunteersManagerProps> = ({
   eventId: _eventId,
   volunteers,
   members,
   onAddVolunteer,
-  isLoading = false
+  isLoading = false,
 }) => {
   const [showAddForm, setShowAddForm] = useState(false);
-  const [formData, setFormData] = useState<CreateVolunteerRequest>({
-    member_id: 0,
-    role: '',
-    contact_phone: '',
-    contact_email: '',
-    arrival_time: '',
-    departure_time: '',
-    special_instructions: '',
-    equipment_needed: [],
-    skills_required: [],
-    volunteer_notes: ''
-  });
-
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
-    if (!formData.member_id || !formData.role) return;
-    
-    await onAddVolunteer(formData);
-    setShowAddForm(false);
-    setFormData({
-      member_id: 0,
-      role: '',
-      contact_phone: '',
-      contact_email: '',
-      arrival_time: '',
-      departure_time: '',
-      special_instructions: '',
-      equipment_needed: [],
-      skills_required: [],
-      volunteer_notes: ''
-    });
-  };
-
-  const handleChange = (field: keyof CreateVolunteerRequest, value: any) => {
-    setFormData(prev => ({ ...prev, [field]: value }));
-  };
-
-  const getMemberName = (memberId: number) => {
-    const member = members.find(m => m.id === memberId);
-    return member ? `${member.first_name} ${member.last_name}` : 'Unknown Member';
-  };
 
   const getVolunteerStatusIcon = (volunteer: EventVolunteer) => {
     if (volunteer.checked_in_at) {
@@ -88,7 +40,7 @@ export const EventVolunteersManager: React.FC<EventVolunteersManagerProps> = ({
   };
 
   return (
-    <div className="bg-white shadow rounded-lg p-6">
+    <>
       <div className="flex justify-between items-center mb-6">
         <h2 className="text-xl font-semibold">Event Volunteers</h2>
         <button
@@ -100,17 +52,35 @@ export const EventVolunteersManager: React.FC<EventVolunteersManagerProps> = ({
         </button>
       </div>
 
+      {/* Add Volunteer Form */}
+      {showAddForm && (
+        <AddVolunteerForm
+          members={members}
+          onAddVolunteer={async (data) => {
+            await onAddVolunteer(data);
+            setShowAddForm(false);
+          }}
+          onCancel={() => setShowAddForm(false)}
+          isLoading={isLoading}
+        />
+      )}
+
       {/* Volunteers List */}
       <div className="space-y-4 mb-6">
         {volunteers.length === 0 ? (
-          <p className="text-gray-500 text-center py-8">No volunteers assigned to this event.</p>
+          <p className="text-gray-500 text-center py-8">
+            No volunteers assigned to this event.
+          </p>
         ) : (
           volunteers.map((volunteer) => (
-            <div key={volunteer.id} className="border border-gray-200 rounded-lg p-4">
+            <div
+              key={volunteer.id}
+              className="border border-gray-200 rounded-lg p-4"
+            >
               <div className="flex justify-between items-start mb-2">
                 <div>
                   <h3 className="font-medium text-lg">
-                    {getMemberName(volunteer.member_id)}
+                    {getMemberName(members, volunteer.member_id)}
                   </h3>
                   <p className="text-gray-600 capitalize">
                     Role: {volunteer.role.replace('_', ' ')}
@@ -124,193 +94,62 @@ export const EventVolunteersManager: React.FC<EventVolunteersManagerProps> = ({
               <div className="grid grid-cols-1 md:grid-cols-2 gap-4 text-sm text-gray-600">
                 {volunteer.contact_phone && (
                   <div>
-                    <span className="font-medium">Phone:</span> {volunteer.contact_phone}
+                    <span className="font-medium">Phone:</span>{' '}
+                    {volunteer.contact_phone}
                   </div>
                 )}
                 {volunteer.contact_email && (
                   <div>
-                    <span className="font-medium">Email:</span> {volunteer.contact_email}
+                    <span className="font-medium">Email:</span>{' '}
+                    {volunteer.contact_email}
                   </div>
                 )}
                 {volunteer.arrival_time && (
                   <div>
-                    <span className="font-medium">Arrival:</span> {formatTime(volunteer.arrival_time)}
+                    <span className="font-medium">Arrival:</span>{' '}
+                    {formatTime(volunteer.arrival_time)}
                   </div>
                 )}
                 {volunteer.departure_time && (
                   <div>
-                    <span className="font-medium">Departure:</span> {formatTime(volunteer.departure_time)}
+                    <span className="font-medium">Departure:</span>{' '}
+                    {formatTime(volunteer.departure_time)}
                   </div>
                 )}
               </div>
 
               {volunteer.special_instructions && (
                 <div className="mt-3 p-2 bg-yellow-50 rounded">
-                  <span className="font-medium text-yellow-800">Special Instructions:</span>
-                  <p className="text-yellow-700 text-sm mt-1">{volunteer.special_instructions}</p>
+                  <span className="font-medium text-yellow-800">
+                    Special Instructions:
+                  </span>
+                  <p className="text-yellow-700 text-sm mt-1">
+                    {volunteer.special_instructions}
+                  </p>
                 </div>
               )}
 
               {volunteer.volunteer_notes && (
                 <div className="mt-3 p-2 bg-blue-50 rounded">
-                  <span className="font-medium text-blue-800">Volunteer Notes:</span>
-                  <p className="text-blue-700 text-sm mt-1">{volunteer.volunteer_notes}</p>
+                  <span className="font-medium text-blue-800">
+                    Volunteer Notes:
+                  </span>
+                  <p className="text-blue-700 text-sm mt-1">
+                    {volunteer.volunteer_notes}
+                  </p>
                 </div>
               )}
 
               {volunteer.hours_worked && (
                 <div className="mt-2 text-sm text-gray-600">
-                  <span className="font-medium">Hours Worked:</span> {volunteer.hours_worked}
+                  <span className="font-medium">Hours Worked:</span>{' '}
+                  {volunteer.hours_worked}
                 </div>
               )}
             </div>
           ))
         )}
       </div>
-
-      {/* Add Volunteer Form */}
-      {showAddForm && (
-        <div className="border-t pt-6">
-          <h3 className="text-lg font-medium mb-4">Add New Volunteer</h3>
-          <form onSubmit={handleSubmit} className="space-y-4">
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-              <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1">
-                  Member *
-                </label>
-                <select
-                  value={formData.member_id}
-                  onChange={(e) => handleChange('member_id', parseInt(e.target.value))}
-                  className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
-                  required
-                >
-                  <option value={0}>Select a member</option>
-                  {members.map((member) => (
-                    <option key={member.id} value={member.id}>
-                      {member.first_name} {member.last_name}
-                    </option>
-                  ))}
-                </select>
-              </div>
-
-              <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1">
-                  Role *
-                </label>
-                <select
-                  value={formData.role}
-                  onChange={(e) => handleChange('role', e.target.value)}
-                  className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
-                  required
-                >
-                  <option value="">Select a role</option>
-                  {VOLUNTEER_ROLES.map((role) => (
-                    <option key={role} value={role}>
-                      {role.replace('_', ' ').replace(/\b\w/g, l => l.toUpperCase())}
-                    </option>
-                  ))}
-                </select>
-              </div>
-            </div>
-
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-              <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1">
-                  Contact Phone
-                </label>
-                <input
-                  type="tel"
-                  value={formData.contact_phone}
-                  onChange={(e) => handleChange('contact_phone', e.target.value)}
-                  className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
-                />
-              </div>
-
-              <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1">
-                  Contact Email
-                </label>
-                <input
-                  type="email"
-                  value={formData.contact_email}
-                  onChange={(e) => handleChange('contact_email', e.target.value)}
-                  className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
-                />
-              </div>
-            </div>
-
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-              <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1">
-                  Arrival Time
-                </label>
-                <input
-                  type="datetime-local"
-                  value={formData.arrival_time}
-                  onChange={(e) => handleChange('arrival_time', e.target.value)}
-                  className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
-                />
-              </div>
-
-              <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1">
-                  Departure Time
-                </label>
-                <input
-                  type="datetime-local"
-                  value={formData.departure_time}
-                  onChange={(e) => handleChange('departure_time', e.target.value)}
-                  className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
-                />
-              </div>
-            </div>
-
-            <div>
-              <label className="block text-sm font-medium text-gray-700 mb-1">
-                Special Instructions
-              </label>
-              <textarea
-                value={formData.special_instructions}
-                onChange={(e) => handleChange('special_instructions', e.target.value)}
-                rows={3}
-                className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
-                placeholder="Any special instructions for this volunteer"
-              />
-            </div>
-
-            <div>
-              <label className="block text-sm font-medium text-gray-700 mb-1">
-                Volunteer Notes
-              </label>
-              <textarea
-                value={formData.volunteer_notes}
-                onChange={(e) => handleChange('volunteer_notes', e.target.value)}
-                rows={2}
-                className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
-                placeholder="Notes from the volunteer"
-              />
-            </div>
-
-            <div className="flex justify-end gap-4 pt-4">
-              <button
-                type="button"
-                onClick={() => setShowAddForm(false)}
-                className="px-4 py-2 border border-gray-300 rounded-md text-gray-700 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-blue-500"
-                disabled={isLoading}
-              >
-                Cancel
-              </button>
-              <button
-                type="submit"
-                disabled={isLoading || !formData.member_id || !formData.role}
-                className="px-4 py-2 bg-blue-500 text-white rounded-md hover:bg-blue-600 focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:opacity-50"
-              >
-                {isLoading ? 'Adding...' : 'Add Volunteer'}
-              </button>
-            </div>
-          </form>
-        </div>
-      )}
-    </div>
+    </>
   );
 };

--- a/administration/client/src/components/Layout.tsx
+++ b/administration/client/src/components/Layout.tsx
@@ -1,11 +1,11 @@
-import { ReactNode } from 'react';
-import { Link, useLocation } from 'react-router-dom';
 import {
-  HomeIcon,
-  UsersIcon,
   CalendarIcon,
   CogIcon,
+  HomeIcon,
+  UsersIcon,
 } from '@heroicons/react/24/outline';
+import { ReactNode } from 'react';
+import { Link, useLocation } from 'react-router-dom';
 
 interface LayoutProps {
   children: ReactNode;
@@ -26,11 +26,6 @@ export function Layout({ children }: LayoutProps) {
       <div className="flex">
         {/* Sidebar */}
         <div className="w-64 bg-white shadow-lg">
-          <div className="p-6">
-            <h1 className="text-xl font-bold text-gray-900">
-              Club Management
-            </h1>
-          </div>
           <nav className="mt-6">
             {navigation.map((item) => {
               const isActive = location.pathname === item.href;
@@ -54,9 +49,7 @@ export function Layout({ children }: LayoutProps) {
 
         {/* Main content */}
         <div className="flex-1">
-          <main className="p-8">
-            {children}
-          </main>
+          <main className="p-8">{children}</main>
         </div>
       </div>
     </div>

--- a/administration/client/src/features/EventDetails/components/Attendance.tsx
+++ b/administration/client/src/features/EventDetails/components/Attendance.tsx
@@ -1,0 +1,80 @@
+import { EventAttendance } from '@/types';
+
+interface AttendanceProps {
+  attendance: EventAttendance[];
+}
+
+export function Attendance({ attendance }: AttendanceProps) {
+  const formatDateTime = (dateTime: string) => {
+    return new Date(dateTime).toLocaleString();
+  };
+
+  if (attendance.length === 0) {
+    return (
+      <div>
+        <h3 className="text-lg font-medium mb-4">Event Attendance</h3>
+        <p className="text-gray-500 text-center py-8">No attendance records yet.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <h3 className="text-lg font-medium mb-4">Event Attendance</h3>
+      
+      <div className="overflow-x-auto">
+        <table className="min-w-full divide-y divide-gray-200">
+          <thead className="bg-gray-50">
+            <tr>
+              <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                Member
+              </th>
+              <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                Ticket Type
+              </th>
+              <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                Registration
+              </th>
+              <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                Check-in Status
+              </th>
+            </tr>
+          </thead>
+          <tbody className="bg-white divide-y divide-gray-200">
+            {attendance.map((record) => (
+              <tr key={record.id}>
+                <td className="px-6 py-4 whitespace-nowrap">
+                  <div className="text-sm font-medium text-gray-900">
+                    {record.member_id ? `Member ${record.member_id}` : 'Non-member'}
+                  </div>
+                  {record.eventbrite_attendee_id && (
+                    <div className="text-sm text-gray-500">
+                      Eventbrite: {record.eventbrite_attendee_id}
+                    </div>
+                  )}
+                </td>
+                <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
+                  {record.ticket_type || 'N/A'}
+                </td>
+                <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                  {record.registration_date ? formatDateTime(record.registration_date) : 'N/A'}
+                </td>
+                <td className="px-6 py-4 whitespace-nowrap">
+                  {record.check_in_method ? (
+                    <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-green-100 text-green-800">
+                      Checked In ({record.check_in_method})
+                    </span>
+                  ) : (
+                    <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-yellow-100 text-yellow-800">
+                      Not Checked In
+                    </span>
+                  )}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/administration/client/src/features/EventDetails/components/Header.tsx
+++ b/administration/client/src/features/EventDetails/components/Header.tsx
@@ -1,0 +1,122 @@
+import { Event, EventWithDetails } from '@/types';
+import { ArrowLeftIcon, PencilIcon } from '@heroicons/react/24/outline';
+import { useMemo } from 'react';
+
+interface HeaderProps {
+  event: Event;
+  eventDetails: EventWithDetails;
+  onBack: () => void;
+  onEdit: () => void;
+}
+
+export function Header({ event, eventDetails, onBack, onEdit }: HeaderProps) {
+  const formatDateTime = (dateTime: string) => {
+    return new Date(dateTime).toLocaleString();
+  };
+
+  const status = useMemo(() => {
+    const now = new Date();
+    const start = new Date(event.start_datetime);
+    const end = new Date(event.end_datetime);
+
+    if (now < start) return 'upcoming';
+    if (now >= start && now <= end) return 'ongoing';
+    return 'past';
+  }, [event.start_datetime, event.end_datetime]);
+
+  const isActive = event.flags & 1;
+  const isPublic = event.flags & 2;
+
+  return (
+    <div className="mb-6">
+      <div className="flex items-center justify-between mb-4">
+        <button
+          onClick={onBack}
+          className="flex items-center text-gray-600 hover:text-gray-900"
+        >
+          <ArrowLeftIcon className="h-5 w-5 mr-2" />
+          Back to Events
+        </button>
+      </div>
+
+      <div className="bg-white shadow rounded-lg p-6">
+        <div className="flex justify-between items-start mb-4">
+          <div>
+            <h1 className="text-3xl font-bold text-gray-900 mb-2">
+              {event.name}
+            </h1>
+            {event.description && (
+              <p className="text-gray-600 mb-4">{event.description}</p>
+            )}
+            <div className="flex space-x-2">
+              <span
+                className={`inline-flex items-center px-3 py-1 rounded-full text-sm font-medium ${
+                  status === 'upcoming'
+                    ? 'bg-blue-100 text-blue-800'
+                    : status === 'ongoing'
+                      ? 'bg-green-100 text-green-800'
+                      : 'bg-gray-100 text-gray-800'
+                }`}
+              >
+                {status === 'upcoming'
+                  ? 'Upcoming'
+                  : status === 'ongoing'
+                    ? 'Ongoing'
+                    : 'Past'}
+              </span>
+              {isPublic && (
+                <span className="inline-flex items-center px-3 py-1 rounded-full text-sm font-medium bg-purple-100 text-purple-800">
+                  Public
+                </span>
+              )}
+              {!isActive && (
+                <span className="inline-flex items-center px-3 py-1 rounded-full text-sm font-medium bg-red-100 text-red-800">
+                  Inactive
+                </span>
+              )}
+            </div>
+          </div>
+          <button
+            onClick={onEdit}
+            className="flex items-center px-4 py-2 border border-gray-300 rounded-md text-gray-700 hover:bg-gray-50"
+          >
+            <PencilIcon className="h-4 w-4 mr-2" />
+            Edit Event
+          </button>
+        </div>
+
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-6 text-sm">
+          <div>
+            <span className="font-medium text-gray-700">Start:</span>
+            <div className="text-gray-900">
+              {formatDateTime(event.start_datetime)}
+            </div>
+          </div>
+          <div>
+            <span className="font-medium text-gray-700">End:</span>
+            <div className="text-gray-900">
+              {formatDateTime(event.end_datetime)}
+            </div>
+          </div>
+          <div>
+            <span className="font-medium text-gray-700">Capacity:</span>
+            <div className="text-gray-900">
+              {event.max_capacity || 'Unlimited'}
+            </div>
+          </div>
+        </div>
+
+        {eventDetails.eventbrite_link && (
+          <div className="mt-4 p-3 bg-blue-50 rounded-md">
+            <span className="text-blue-800 font-medium">
+              Eventbrite Integration:
+            </span>
+            <span className="text-blue-700 ml-2">
+              Sync Status: {eventDetails.eventbrite_link.sync_status}
+            </span>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/administration/client/src/features/EventDetails/components/LoadingStates.tsx
+++ b/administration/client/src/features/EventDetails/components/LoadingStates.tsx
@@ -1,0 +1,34 @@
+interface LoadingStatesProps {
+  isLoading: boolean;
+  error: Error | null;
+}
+
+export function LoadingStates({ isLoading, error }: LoadingStatesProps) {
+  if (isLoading) {
+    return (
+      <div className="flex justify-center items-center h-64">
+        <div className="text-gray-500">Loading event details...</div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="text-center py-12">
+        <div className="text-red-600 mb-4">Failed to load event</div>
+        <button
+          onClick={() => window.location.reload()}
+          className="bg-blue-600 text-white px-4 py-2 rounded-md hover:bg-blue-700"
+        >
+          Retry
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="text-center py-12">
+      <h2 className="text-2xl font-semibold text-gray-900 mb-4">Event not found</h2>
+    </div>
+  );
+}

--- a/administration/client/src/features/EventDetails/components/Marketing.tsx
+++ b/administration/client/src/features/EventDetails/components/Marketing.tsx
@@ -1,0 +1,65 @@
+import { EventMarketing } from '@/types';
+
+interface MarketingProps {
+  marketing?: EventMarketing;
+  onEditMarketing: () => void;
+}
+
+export function Marketing({ marketing, onEditMarketing }: MarketingProps) {
+  if (!marketing) {
+    return (
+      <div className="text-center py-12">
+        <h3 className="text-lg font-medium text-gray-900 mb-4">
+          No marketing content yet
+        </h3>
+        <button
+          onClick={onEditMarketing}
+          className="px-4 py-2 bg-blue-500 text-white rounded-md hover:bg-blue-600"
+        >
+          Add Marketing Content
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="flex justify-between items-center">
+        <h3 className="text-lg font-medium">Marketing Content</h3>
+        <button
+          onClick={onEditMarketing}
+          className="px-4 py-2 bg-blue-500 text-white rounded-md hover:bg-blue-600"
+        >
+          Edit Marketing
+        </button>
+      </div>
+
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+        <div>
+          <h4 className="font-medium text-gray-900 mb-2">Primary Copy</h4>
+          <p className="text-gray-700 text-sm">
+            {marketing.primary_marketing_copy || 'Not set'}
+          </p>
+        </div>
+        <div>
+          <h4 className="font-medium text-gray-900 mb-2">Blurb</h4>
+          <p className="text-gray-700 text-sm">
+            {marketing.blurb || 'Not set'}
+          </p>
+        </div>
+        <div>
+          <h4 className="font-medium text-gray-900 mb-2">Social Media Copy</h4>
+          <p className="text-gray-700 text-sm">
+            {marketing.social_media_copy || 'Not set'}
+          </p>
+        </div>
+        <div>
+          <h4 className="font-medium text-gray-900 mb-2">Email Subject</h4>
+          <p className="text-gray-700 text-sm">
+            {marketing.email_subject || 'Not set'}
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/administration/client/src/features/EventDetails/components/Overview.tsx
+++ b/administration/client/src/features/EventDetails/components/Overview.tsx
@@ -1,0 +1,53 @@
+import { EventWithDetails, EventVolunteer, EventAttendance } from '@/types';
+
+interface OverviewProps {
+  eventDetails: EventWithDetails;
+  volunteers: EventVolunteer[];
+  attendance: EventAttendance[];
+}
+
+export function Overview({ eventDetails, volunteers, attendance }: OverviewProps) {
+  return (
+    <div className="space-y-6">
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+        <div className="bg-gray-50 p-4 rounded-md">
+          <h3 className="font-medium text-gray-900 mb-2">Event Statistics</h3>
+          <dl className="space-y-2 text-sm">
+            <div className="flex justify-between">
+              <dt className="text-gray-600">Total Registrations:</dt>
+              <dd className="font-medium">{attendance.length}</dd>
+            </div>
+            <div className="flex justify-between">
+              <dt className="text-gray-600">Volunteers:</dt>
+              <dd className="font-medium">{volunteers.length}</dd>
+            </div>
+            <div className="flex justify-between">
+              <dt className="text-gray-600">Checked In:</dt>
+              <dd className="font-medium">
+                {attendance.filter(a => a.check_in_method).length}
+              </dd>
+            </div>
+          </dl>
+        </div>
+
+        {eventDetails.eventbrite_event && (
+          <div className="bg-gray-50 p-4 rounded-md">
+            <h3 className="font-medium text-gray-900 mb-2">Eventbrite Info</h3>
+            <dl className="space-y-2 text-sm">
+              <div className="flex justify-between">
+                <dt className="text-gray-600">Capacity:</dt>
+                <dd className="font-medium">{eventDetails.eventbrite_event.capacity || 'N/A'}</dd>
+              </div>
+              <div className="flex justify-between">
+                <dt className="text-gray-600">Last Synced:</dt>
+                <dd className="font-medium">
+                  {new Date(eventDetails.eventbrite_event.last_synced_at).toLocaleString()}
+                </dd>
+              </div>
+            </dl>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/administration/client/src/features/EventDetails/components/Tabs.tsx
+++ b/administration/client/src/features/EventDetails/components/Tabs.tsx
@@ -1,0 +1,44 @@
+import { ReactNode } from 'react';
+
+interface TabsProps {
+  activeTab: 'overview' | 'marketing' | 'volunteers' | 'attendance';
+  onTabChange: (tab: 'overview' | 'marketing' | 'volunteers' | 'attendance') => void;
+  volunteersCount: number;
+  attendanceCount: number;
+  children: ReactNode;
+}
+
+export function Tabs({ activeTab, onTabChange, volunteersCount, attendanceCount, children }: TabsProps) {
+  const tabs = [
+    { key: 'overview', label: 'Overview' },
+    { key: 'marketing', label: 'Marketing' },
+    { key: 'volunteers', label: `Volunteers (${volunteersCount})` },
+    { key: 'attendance', label: `Attendance (${attendanceCount})` }
+  ] as const;
+
+  return (
+    <div className="bg-white shadow rounded-lg">
+      <div className="border-b border-gray-200">
+        <nav className="flex space-x-8 px-6">
+          {tabs.map((tab) => (
+            <button
+              key={tab.key}
+              onClick={() => onTabChange(tab.key)}
+              className={`py-4 px-1 border-b-2 font-medium text-sm ${
+                activeTab === tab.key
+                  ? 'border-blue-500 text-blue-600'
+                  : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300'
+              }`}
+            >
+              {tab.label}
+            </button>
+          ))}
+        </nav>
+      </div>
+
+      <div className="p-6">
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/administration/client/src/features/EventDetails/components/index.ts
+++ b/administration/client/src/features/EventDetails/components/index.ts
@@ -1,0 +1,6 @@
+export { Header } from './Header';
+export { Tabs } from './Tabs';
+export { Overview } from './Overview';
+export { Marketing } from './Marketing';
+export { Attendance } from './Attendance';
+export { LoadingStates } from './LoadingStates';

--- a/administration/client/src/features/EventDetails/hooks/useEventCrud.ts
+++ b/administration/client/src/features/EventDetails/hooks/useEventCrud.ts
@@ -1,0 +1,49 @@
+import { EventService } from '@/services/eventService';
+import { CreateEventMarketingRequest, CreateVolunteerRequest } from '@/types';
+import { useQueryClient } from '@tanstack/react-query';
+import { useState } from 'react';
+
+export function useEventCrud(eventId: number) {
+  const [marketingLoading, setMarketingLoading] = useState(false);
+  const [volunteerLoading, setVolunteerLoading] = useState(false);
+  const queryClient = useQueryClient();
+
+  const handleMarketingSubmit = async (data: CreateEventMarketingRequest) => {
+    try {
+      setMarketingLoading(true);
+      await EventService.createEventMarketing(eventId, data);
+      // Invalidate and refetch event details
+      queryClient.invalidateQueries({
+        queryKey: ['events', 'details', eventId],
+      });
+    } catch (error) {
+      console.error('Failed to save marketing:', error);
+      alert('Failed to save marketing content. Please try again.');
+    } finally {
+      setMarketingLoading(false);
+    }
+  };
+
+  const handleVolunteerSubmit = async (data: CreateVolunteerRequest) => {
+    try {
+      setVolunteerLoading(true);
+      await EventService.addVolunteer(eventId, data);
+      // Invalidate and refetch event details
+      queryClient.invalidateQueries({
+        queryKey: ['events', 'details', eventId],
+      });
+    } catch (error) {
+      console.error('Failed to add volunteer:', error);
+      alert('Failed to add volunteer. Please try again.');
+    } finally {
+      setVolunteerLoading(false);
+    }
+  };
+
+  return {
+    marketingLoading,
+    volunteerLoading,
+    handleMarketingSubmit,
+    handleVolunteerSubmit,
+  };
+}

--- a/administration/client/src/features/Events/components/EventFormModal.tsx
+++ b/administration/client/src/features/Events/components/EventFormModal.tsx
@@ -1,0 +1,34 @@
+import { Modal } from '../../../components/Modal';
+import { EventForm } from '../../../components/EventForm';
+import { Event, EventFormData } from '../../../types';
+
+interface EventFormModalProps {
+  isOpen: boolean;
+  editingEvent: Event | null;
+  onSubmit: (formData: EventFormData) => Promise<void>;
+  onClose: () => void;
+  isLoading: boolean;
+}
+
+export function EventFormModal({
+  isOpen,
+  editingEvent,
+  onSubmit,
+  onClose,
+  isLoading,
+}: EventFormModalProps) {
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={onClose}
+      title={editingEvent ? 'Edit Event' : 'Create New Event'}
+    >
+      <EventForm
+        event={editingEvent || undefined}
+        onSubmit={onSubmit}
+        onCancel={onClose}
+        isLoading={isLoading}
+      />
+    </Modal>
+  );
+}

--- a/administration/client/src/features/Events/components/EventGrid.tsx
+++ b/administration/client/src/features/Events/components/EventGrid.tsx
@@ -1,0 +1,122 @@
+import { CalendarIcon } from '@heroicons/react/24/outline';
+import { Event } from '../../../types';
+import { EventTableRow } from './EventTableRow';
+
+type EventFilter = 'upcoming' | 'past' | 'all';
+
+interface EventGridProps {
+  events: Event[];
+  isLoading: boolean;
+  onEdit: (event: Event) => void;
+  onDelete: (event: Event) => void;
+  onView: (event: Event) => void;
+  isEditPending: boolean;
+  isDeletePending: boolean;
+  filter: EventFilter;
+  onFilterChange: (filter: EventFilter) => void;
+  children?: React.ReactNode;
+}
+
+export function EventGrid({
+  events,
+  isLoading,
+  onEdit,
+  onDelete,
+  onView,
+  isEditPending,
+  isDeletePending,
+  filter,
+  onFilterChange,
+  children,
+}: EventGridProps) {
+  return (
+    <div className="bg-white shadow rounded-lg">
+      <div className="p-6 border-b border-gray-200">
+        <div className="flex items-center space-x-4">
+          <button 
+            onClick={() => onFilterChange('upcoming')}
+            className={`px-4 py-2 rounded-md ${
+              filter === 'upcoming' 
+                ? 'bg-blue-100 text-blue-700' 
+                : 'text-gray-600 hover:bg-gray-100'
+            }`}
+          >
+            Upcoming
+          </button>
+          <button 
+            onClick={() => onFilterChange('past')}
+            className={`px-4 py-2 rounded-md ${
+              filter === 'past' 
+                ? 'bg-blue-100 text-blue-700' 
+                : 'text-gray-600 hover:bg-gray-100'
+            }`}
+          >
+            Past
+          </button>
+          <button 
+            onClick={() => onFilterChange('all')}
+            className={`px-4 py-2 rounded-md ${
+              filter === 'all' 
+                ? 'bg-blue-100 text-blue-700' 
+                : 'text-gray-600 hover:bg-gray-100'
+            }`}
+          >
+            All
+          </button>
+        </div>
+      </div>
+
+      {isLoading ? (
+        <div className="p-6 text-center text-gray-500">
+          Loading events...
+        </div>
+      ) : events.length === 0 ? (
+        <div className="p-6">
+          <div className="text-center text-gray-500">
+            <CalendarIcon className="mx-auto h-12 w-12 text-gray-400 mb-4" />
+            <h3 className="text-lg font-medium text-gray-900 mb-2">No events scheduled</h3>
+            <p>Get started by creating your first event.</p>
+          </div>
+        </div>
+      ) : (
+        <div className="overflow-x-auto">
+          <table className="min-w-full divide-y divide-gray-200">
+            <thead className="bg-gray-50">
+              <tr>
+                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                  Event
+                </th>
+                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                  Date & Time
+                </th>
+                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                  Capacity
+                </th>
+                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                  Status
+                </th>
+                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                  Actions
+                </th>
+              </tr>
+            </thead>
+            <tbody className="bg-white divide-y divide-gray-200">
+              {events.map((event) => (
+                <EventTableRow
+                  key={event.id}
+                  event={event}
+                  onEdit={onEdit}
+                  onDelete={onDelete}
+                  onView={onView}
+                  isEditPending={isEditPending}
+                  isDeletePending={isDeletePending}
+                />
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+      {children}
+    </div>
+  );
+}

--- a/administration/client/src/features/Events/components/EventGrid.tsx
+++ b/administration/client/src/features/Events/components/EventGrid.tsx
@@ -1,17 +1,11 @@
 import { CalendarIcon } from '@heroicons/react/24/outline';
 import { Event } from '../../../types';
-import { EventTableRow } from './EventTableRow';
 
 type EventFilter = 'upcoming' | 'past' | 'all';
 
 interface EventGridProps {
   events: Event[];
   isLoading: boolean;
-  onEdit: (event: Event) => void;
-  onDelete: (event: Event) => void;
-  onView: (event: Event) => void;
-  isEditPending: boolean;
-  isDeletePending: boolean;
   filter: EventFilter;
   onFilterChange: (filter: EventFilter) => void;
   children?: React.ReactNode;
@@ -20,11 +14,6 @@ interface EventGridProps {
 export function EventGrid({
   events,
   isLoading,
-  onEdit,
-  onDelete,
-  onView,
-  isEditPending,
-  isDeletePending,
   filter,
   onFilterChange,
   children,
@@ -33,31 +22,31 @@ export function EventGrid({
     <div className="bg-white shadow rounded-lg">
       <div className="p-6 border-b border-gray-200">
         <div className="flex items-center space-x-4">
-          <button 
+          <button
             onClick={() => onFilterChange('upcoming')}
             className={`px-4 py-2 rounded-md ${
-              filter === 'upcoming' 
-                ? 'bg-blue-100 text-blue-700' 
+              filter === 'upcoming'
+                ? 'bg-blue-100 text-blue-700'
                 : 'text-gray-600 hover:bg-gray-100'
             }`}
           >
             Upcoming
           </button>
-          <button 
+          <button
             onClick={() => onFilterChange('past')}
             className={`px-4 py-2 rounded-md ${
-              filter === 'past' 
-                ? 'bg-blue-100 text-blue-700' 
+              filter === 'past'
+                ? 'bg-blue-100 text-blue-700'
                 : 'text-gray-600 hover:bg-gray-100'
             }`}
           >
             Past
           </button>
-          <button 
+          <button
             onClick={() => onFilterChange('all')}
             className={`px-4 py-2 rounded-md ${
-              filter === 'all' 
-                ? 'bg-blue-100 text-blue-700' 
+              filter === 'all'
+                ? 'bg-blue-100 text-blue-700'
                 : 'text-gray-600 hover:bg-gray-100'
             }`}
           >
@@ -67,14 +56,14 @@ export function EventGrid({
       </div>
 
       {isLoading ? (
-        <div className="p-6 text-center text-gray-500">
-          Loading events...
-        </div>
+        <div className="p-6 text-center text-gray-500">Loading events...</div>
       ) : events.length === 0 ? (
         <div className="p-6">
           <div className="text-center text-gray-500">
             <CalendarIcon className="mx-auto h-12 w-12 text-gray-400 mb-4" />
-            <h3 className="text-lg font-medium text-gray-900 mb-2">No events scheduled</h3>
+            <h3 className="text-lg font-medium text-gray-900 mb-2">
+              No events scheduled
+            </h3>
             <p>Get started by creating your first event.</p>
           </div>
         </div>
@@ -101,22 +90,11 @@ export function EventGrid({
               </tr>
             </thead>
             <tbody className="bg-white divide-y divide-gray-200">
-              {events.map((event) => (
-                <EventTableRow
-                  key={event.id}
-                  event={event}
-                  onEdit={onEdit}
-                  onDelete={onDelete}
-                  onView={onView}
-                  isEditPending={isEditPending}
-                  isDeletePending={isDeletePending}
-                />
-              ))}
+              {children}
             </tbody>
           </table>
         </div>
       )}
-      {children}
     </div>
   );
 }

--- a/administration/client/src/features/Events/components/EventStatusBadge.tsx
+++ b/administration/client/src/features/Events/components/EventStatusBadge.tsx
@@ -1,0 +1,44 @@
+import { Event } from '../../../types';
+
+interface EventStatusBadgeProps {
+  event: Event;
+}
+
+export function EventStatusBadge({ event }: EventStatusBadgeProps) {
+  const getEventStatus = (event: Event) => {
+    const now = new Date();
+    const start = new Date(event.start_datetime);
+    const end = new Date(event.end_datetime);
+    
+    if (now < start) return 'upcoming';
+    if (now >= start && now <= end) return 'ongoing';
+    return 'past';
+  };
+
+  const status = getEventStatus(event);
+  const isActive = event.flags & 1;
+  const isPublic = event.flags & 2;
+  
+  return (
+    <div className="flex space-x-1">
+      <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${
+        status === 'upcoming' ? 'bg-blue-100 text-blue-800' :
+        status === 'ongoing' ? 'bg-green-100 text-green-800' :
+        'bg-gray-100 text-gray-800'
+      }`}>
+        {status === 'upcoming' ? 'Upcoming' :
+         status === 'ongoing' ? 'Ongoing' : 'Past'}
+      </span>
+      {isPublic && (
+        <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-purple-100 text-purple-800">
+          Public
+        </span>
+      )}
+      {!isActive && (
+        <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-red-100 text-red-800">
+          Inactive
+        </span>
+      )}
+    </div>
+  );
+}

--- a/administration/client/src/features/Events/components/EventTableRow.tsx
+++ b/administration/client/src/features/Events/components/EventTableRow.tsx
@@ -1,4 +1,5 @@
-import { PencilIcon, TrashIcon, EyeIcon } from '@heroicons/react/24/outline';
+import { PencilIcon, TrashIcon } from '@heroicons/react/24/outline';
+import { Link } from 'react-router-dom';
 import { Event } from '../../../types';
 import { EventStatusBadge } from './EventStatusBadge';
 
@@ -6,7 +7,6 @@ interface EventTableRowProps {
   event: Event;
   onEdit: (event: Event) => void;
   onDelete: (event: Event) => void;
-  onView: (event: Event) => void;
   isEditPending: boolean;
   isDeletePending: boolean;
 }
@@ -15,7 +15,6 @@ export function EventTableRow({
   event,
   onEdit,
   onDelete,
-  onView,
   isEditPending,
   isDeletePending,
 }: EventTableRowProps) {
@@ -28,7 +27,12 @@ export function EventTableRow({
       <td className="px-6 py-4">
         <div>
           <div className="text-sm font-medium text-gray-900">
-            {event.name}
+            <Link
+              className="text-blue-600 hover:text-blue-900"
+              to={`/events/${event.id}`}
+            >
+              {event.name}
+            </Link>
           </div>
           {event.description && (
             <div className="text-sm text-gray-500 truncate max-w-xs">
@@ -53,13 +57,6 @@ export function EventTableRow({
       </td>
       <td className="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
         <div className="flex space-x-2">
-          <button
-            onClick={() => onView(event)}
-            className="text-green-600 hover:text-green-900"
-            title="View Details"
-          >
-            <EyeIcon className="h-4 w-4" />
-          </button>
           <button
             onClick={() => onEdit(event)}
             disabled={isEditPending}

--- a/administration/client/src/features/Events/components/EventTableRow.tsx
+++ b/administration/client/src/features/Events/components/EventTableRow.tsx
@@ -1,0 +1,83 @@
+import { PencilIcon, TrashIcon, EyeIcon } from '@heroicons/react/24/outline';
+import { Event } from '../../../types';
+import { EventStatusBadge } from './EventStatusBadge';
+
+interface EventTableRowProps {
+  event: Event;
+  onEdit: (event: Event) => void;
+  onDelete: (event: Event) => void;
+  onView: (event: Event) => void;
+  isEditPending: boolean;
+  isDeletePending: boolean;
+}
+
+export function EventTableRow({
+  event,
+  onEdit,
+  onDelete,
+  onView,
+  isEditPending,
+  isDeletePending,
+}: EventTableRowProps) {
+  const formatDateTime = (dateString: string) => {
+    return new Date(dateString).toLocaleString();
+  };
+
+  return (
+    <tr className="hover:bg-gray-50">
+      <td className="px-6 py-4">
+        <div>
+          <div className="text-sm font-medium text-gray-900">
+            {event.name}
+          </div>
+          {event.description && (
+            <div className="text-sm text-gray-500 truncate max-w-xs">
+              {event.description}
+            </div>
+          )}
+        </div>
+      </td>
+      <td className="px-6 py-4 whitespace-nowrap">
+        <div className="text-sm text-gray-900">
+          <div>Start: {formatDateTime(event.start_datetime)}</div>
+          <div>End: {formatDateTime(event.end_datetime)}</div>
+        </div>
+      </td>
+      <td className="px-6 py-4 whitespace-nowrap">
+        <div className="text-sm text-gray-900">
+          {event.max_capacity || 'Unlimited'}
+        </div>
+      </td>
+      <td className="px-6 py-4 whitespace-nowrap">
+        <EventStatusBadge event={event} />
+      </td>
+      <td className="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
+        <div className="flex space-x-2">
+          <button
+            onClick={() => onView(event)}
+            className="text-green-600 hover:text-green-900"
+            title="View Details"
+          >
+            <EyeIcon className="h-4 w-4" />
+          </button>
+          <button
+            onClick={() => onEdit(event)}
+            disabled={isEditPending}
+            className="text-blue-600 hover:text-blue-900 disabled:opacity-50"
+            title="Edit Event"
+          >
+            <PencilIcon className="h-4 w-4" />
+          </button>
+          <button
+            onClick={() => onDelete(event)}
+            disabled={isDeletePending}
+            className="text-red-600 hover:text-red-900 disabled:opacity-50"
+            title="Delete Event"
+          >
+            <TrashIcon className="h-4 w-4" />
+          </button>
+        </div>
+      </td>
+    </tr>
+  );
+}

--- a/administration/client/src/features/Events/components/index.ts
+++ b/administration/client/src/features/Events/components/index.ts
@@ -1,0 +1,4 @@
+export { EventGrid } from './EventGrid';
+export { EventFormModal } from './EventFormModal';
+export { EventTableRow } from './EventTableRow';
+export { EventStatusBadge } from './EventStatusBadge';

--- a/administration/client/src/features/Events/hooks/useEventCrud.tsx
+++ b/administration/client/src/features/Events/hooks/useEventCrud.tsx
@@ -1,0 +1,70 @@
+import { useNavigate } from 'react-router-dom';
+import {
+  useCreateEvent,
+  useDeleteEvent,
+  useUpdateEvent,
+} from '../../../hooks/useEvents';
+import { Event, EventFormData } from '../../../types';
+
+export function useEventCrud() {
+  const navigate = useNavigate();
+
+  const createEvent = useCreateEvent();
+  const updateEvent = useUpdateEvent();
+  const deleteEvent = useDeleteEvent();
+
+  const handleDeleteEvent = async (event: Event) => {
+    if (!confirm(`Are you sure you want to delete "${event.name}"?`)) {
+      return;
+    }
+
+    try {
+      await deleteEvent.mutateAsync(event.id);
+    } catch (error) {
+      console.error('Failed to delete event:', error);
+      alert('Failed to delete event. Please try again.');
+    }
+  };
+
+  const handleFormSubmit = async (
+    formData: EventFormData,
+    editingEvent: Event | null,
+    onSuccess: () => void
+  ) => {
+    const eventData = {
+      name: formData.name,
+      description: formData.description || undefined,
+      start_datetime: formData.start_datetime,
+      end_datetime: formData.end_datetime,
+      is_public: formData.is_public,
+      max_capacity: formData.max_capacity ? parseInt(formData.max_capacity) : undefined,
+    };
+    
+    try {
+      if (editingEvent) {
+        await updateEvent.mutateAsync({
+          id: editingEvent.id,
+          ...eventData
+        });
+        onSuccess();
+      } else {
+        const result = await createEvent.mutateAsync(eventData);
+        onSuccess();
+        // Redirect to the newly created event details page
+        navigate(`/events/${result.data.id}`);
+      }
+    } catch (error) {
+      console.error('Failed to save event:', error);
+      alert('Failed to save event. Please try again.');
+    }
+  };
+
+  return {
+    handleDeleteEvent,
+    handleFormSubmit,
+    isCreatePending: createEvent.isPending,
+    isUpdatePending: updateEvent.isPending,
+    isDeletePending: deleteEvent.isPending,
+    isFormLoading: createEvent.isPending || updateEvent.isPending,
+  };
+}

--- a/administration/client/src/features/MemberDetails/components/ApplicationNotes.tsx
+++ b/administration/client/src/features/MemberDetails/components/ApplicationNotes.tsx
@@ -1,0 +1,80 @@
+import { ChatBubbleLeftIcon } from '@heroicons/react/24/outline';
+import { useMutation } from '@tanstack/react-query';
+import { useState } from 'react';
+import { api } from '../../../lib/api';
+
+interface ApplicationNotesProps {
+  memberId: number;
+  onNoteAdded: () => void;
+}
+
+export function ApplicationNotes({
+  memberId,
+  onNoteAdded,
+}: ApplicationNotesProps) {
+  const [noteContent, setNoteContent] = useState('');
+
+  const addNoteMutation = useMutation({
+    mutationFn: async ({ content }: { content: string }) => {
+      const response = await api.post(`/audit`, {
+        entity_type: 'member',
+        entity_id: memberId,
+        action: 'note',
+        metadata: {
+          content,
+        },
+      });
+      return response.data;
+    },
+    onSuccess: () => {
+      onNoteAdded();
+      setNoteContent('');
+    },
+  });
+
+  const handleSubmitNote = async (e: React.FormEvent) => {
+    e.preventDefault();
+
+    if (!noteContent.trim()) {
+      return;
+    }
+
+    try {
+      await addNoteMutation.mutateAsync({ content: noteContent.trim() });
+    } catch (error) {
+      console.error('Failed to add note:', error);
+      alert('Failed to add note. Please try again.');
+    }
+  };
+
+  return (
+    <div className="mt-6 bg-white shadow rounded-lg p-6">
+      <h2 className="text-lg font-semibold text-gray-900 mb-3 flex items-center">
+        <ChatBubbleLeftIcon className="h-5 w-5 mr-2" />
+        Notes
+      </h2>
+
+      <form onSubmit={handleSubmitNote} className="mb-4">
+        <div className="flex gap-3">
+          <textarea
+            id="noteContent"
+            rows={2}
+            value={noteContent}
+            onChange={(e) => setNoteContent(e.target.value)}
+            className="flex-1 px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500 text-sm"
+            placeholder="Add a note about this member..."
+            data-testid="member-note-textarea"
+            disabled={addNoteMutation.isPending}
+          />
+          <button
+            type="submit"
+            disabled={!noteContent.trim() || addNoteMutation.isPending}
+            className="px-4 py-2 bg-purple-600 text-white rounded-md hover:bg-purple-700 disabled:opacity-50 disabled:cursor-not-allowed text-sm whitespace-nowrap self-start"
+          >
+            {addNoteMutation.isPending ? 'Adding...' : 'Add Note'}
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/administration/client/src/features/MemberDetails/components/AuditHistory.tsx
+++ b/administration/client/src/features/MemberDetails/components/AuditHistory.tsx
@@ -1,0 +1,110 @@
+import { AuditLogEntry } from '../../../hooks/useAudit';
+
+interface AuditHistoryProps {
+  auditLog: AuditLogEntry[] | undefined;
+}
+
+export function AuditHistory({ auditLog }: AuditHistoryProps) {
+  const getActionBadgeColor = (action: string) => {
+    switch (action) {
+      case 'create':
+        return 'bg-green-100 text-green-800';
+      case 'update':
+        return 'bg-yellow-100 text-yellow-800';
+      case 'delete':
+        return 'bg-red-100 text-red-800';
+      case 'view':
+        return 'bg-blue-100 text-blue-800';
+      case 'note':
+        return 'bg-purple-100 text-purple-800';
+      default:
+        return 'bg-gray-100 text-gray-800';
+    }
+  };
+
+  if (!auditLog || auditLog.length === 0) {
+    return <div className="text-gray-500 text-sm">No audit recorded yet.</div>;
+  }
+
+  return (
+    <div className="space-y-4">
+      {auditLog
+        .filter((entry) => entry.action !== 'view')
+        .map((entry) => (
+          <div key={entry.id} className="border-l-4 border-blue-200 pl-4 py-2">
+            <div className="flex items-center justify-between">
+              <div className="flex items-center space-x-2">
+                <span
+                  className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${getActionBadgeColor(
+                    entry.action
+                  )}`}
+                >
+                  {entry.action.charAt(0).toUpperCase() + entry.action.slice(1)}
+                </span>
+                <span className="text-sm text-gray-600">
+                  {new Date(entry.created_at).toLocaleString()}
+                </span>
+              </div>
+              <span className="text-xs text-gray-400">
+                Session: {entry.user_email || 'unknown'} | IP: {entry.user_ip}
+              </span>
+            </div>
+
+            {entry.action === 'update' &&
+              entry.oldValues &&
+              entry.newValues && (
+                <div className="mt-2 text-sm">
+                  <div className="text-gray-600 mb-1">Changes made:</div>
+                  <div className="bg-gray-50 rounded p-2 space-y-1">
+                    {Object.keys(entry.newValues).map((key) => {
+                      const oldValue = entry.oldValues?.[key];
+                      const newValue = entry.newValues?.[key];
+
+                      if (
+                        oldValue !== newValue &&
+                        key !== 'id' &&
+                        key !== 'updated_at'
+                      ) {
+                        return (
+                          <div key={key} className="text-xs">
+                            <span className="font-medium capitalize">
+                              {key.replace(/_/g, ' ')}:
+                            </span>
+                            <span className="text-red-600 line-through ml-1">
+                              {String(oldValue || '(empty)')}
+                            </span>
+                            <span className="mx-1">→</span>
+                            <span className="text-green-600">
+                              {String(newValue || '(empty)')}
+                            </span>
+                          </div>
+                        );
+                      }
+                      return null;
+                    })}
+                  </div>
+                </div>
+              )}
+
+            {entry.action === 'create' && entry.newValues && (
+              <div className="mt-2 text-sm">
+                <div className="text-gray-600">
+                  Member created with initial data
+                </div>
+              </div>
+            )}
+
+            {entry.action === 'note' && entry.metadata && (
+              <div className="mt-2 text-sm">
+                <div className="bg-purple-50 rounded p-3 border-l-2 border-purple-200">
+                  <div className="text-gray-800 whitespace-pre-wrap">
+                    {entry.metadata.content}
+                  </div>
+                </div>
+              </div>
+            )}
+          </div>
+        ))}
+    </div>
+  );
+}

--- a/administration/client/src/features/MemberDetails/components/EditMemberForm.tsx
+++ b/administration/client/src/features/MemberDetails/components/EditMemberForm.tsx
@@ -1,14 +1,19 @@
 import { useState } from 'react';
-import { Member, MemberFormData } from '../types';
+import { Member, MemberFormData } from '../../../types';
 
-interface MemberFormProps {
+interface EditMemberFormProps {
   member?: Member;
   onSubmit: (data: MemberFormData) => void;
   onCancel: () => void;
   isLoading?: boolean;
 }
 
-export function MemberForm({ member, onSubmit, onCancel, isLoading = false }: MemberFormProps) {
+export function EditMemberForm({
+  member,
+  onSubmit,
+  onCancel,
+  isLoading = false,
+}: EditMemberFormProps) {
   const [formData, setFormData] = useState<MemberFormData>({
     first_name: member?.first_name || '',
     last_name: member?.last_name || '',
@@ -49,11 +54,14 @@ export function MemberForm({ member, onSubmit, onCancel, isLoading = false }: Me
     }
   };
 
-  const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+  const handleChange = (
+    e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
+  ) => {
     const { name, value, type } = e.target;
-    setFormData(prev => ({
+    setFormData((prev) => ({
       ...prev,
-      [name]: type === 'checkbox' ? (e.target as HTMLInputElement).checked : value
+      [name]:
+        type === 'checkbox' ? (e.target as HTMLInputElement).checked : value,
     }));
   };
 
@@ -61,7 +69,10 @@ export function MemberForm({ member, onSubmit, onCancel, isLoading = false }: Me
     <form onSubmit={handleSubmit} className="space-y-6">
       <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
         <div>
-          <label htmlFor="first_name" className="block text-sm font-medium text-gray-700 mb-2">
+          <label
+            htmlFor="first_name"
+            className="block text-sm font-medium text-gray-700 mb-2"
+          >
             First Name *
           </label>
           <input
@@ -73,8 +84,8 @@ export function MemberForm({ member, onSubmit, onCancel, isLoading = false }: Me
             value={formData.first_name}
             onChange={handleChange}
             className={`w-full px-3 py-2 border rounded-md focus:outline-none focus:ring-2 ${
-              errors.first_name 
-                ? 'border-red-300 focus:ring-red-500' 
+              errors.first_name
+                ? 'border-red-300 focus:ring-red-500'
                 : 'border-gray-300 focus:ring-blue-500'
             }`}
           />
@@ -84,7 +95,10 @@ export function MemberForm({ member, onSubmit, onCancel, isLoading = false }: Me
         </div>
 
         <div>
-          <label htmlFor="last_name" className="block text-sm font-medium text-gray-700 mb-2">
+          <label
+            htmlFor="last_name"
+            className="block text-sm font-medium text-gray-700 mb-2"
+          >
             Last Name *
           </label>
           <input
@@ -95,8 +109,8 @@ export function MemberForm({ member, onSubmit, onCancel, isLoading = false }: Me
             value={formData.last_name}
             onChange={handleChange}
             className={`w-full px-3 py-2 border rounded-md focus:outline-none focus:ring-2 ${
-              errors.last_name 
-                ? 'border-red-300 focus:ring-red-500' 
+              errors.last_name
+                ? 'border-red-300 focus:ring-red-500'
                 : 'border-gray-300 focus:ring-blue-500'
             }`}
           />
@@ -106,7 +120,10 @@ export function MemberForm({ member, onSubmit, onCancel, isLoading = false }: Me
         </div>
 
         <div>
-          <label htmlFor="preferred_name" className="block text-sm font-medium text-gray-700 mb-2">
+          <label
+            htmlFor="preferred_name"
+            className="block text-sm font-medium text-gray-700 mb-2"
+          >
             Preferred Name
           </label>
           <input
@@ -120,7 +137,10 @@ export function MemberForm({ member, onSubmit, onCancel, isLoading = false }: Me
         </div>
 
         <div>
-          <label htmlFor="email" className="block text-sm font-medium text-gray-700 mb-2">
+          <label
+            htmlFor="email"
+            className="block text-sm font-medium text-gray-700 mb-2"
+          >
             Email *
           </label>
           <input
@@ -132,8 +152,8 @@ export function MemberForm({ member, onSubmit, onCancel, isLoading = false }: Me
             value={formData.email}
             onChange={handleChange}
             className={`w-full px-3 py-2 border rounded-md focus:outline-none focus:ring-2 ${
-              errors.email 
-                ? 'border-red-300 focus:ring-red-500' 
+              errors.email
+                ? 'border-red-300 focus:ring-red-500'
                 : 'border-gray-300 focus:ring-blue-500'
             }`}
           />
@@ -143,7 +163,10 @@ export function MemberForm({ member, onSubmit, onCancel, isLoading = false }: Me
         </div>
 
         <div>
-          <label htmlFor="pronouns" className="block text-sm font-medium text-gray-700 mb-2">
+          <label
+            htmlFor="pronouns"
+            className="block text-sm font-medium text-gray-700 mb-2"
+          >
             Pronouns
           </label>
           <input
@@ -166,13 +189,18 @@ export function MemberForm({ member, onSubmit, onCancel, isLoading = false }: Me
               onChange={handleChange}
               className="rounded border-gray-300 text-blue-600 focus:ring-blue-500"
             />
-            <span className="ml-2 text-sm text-gray-700">Professional Affiliate</span>
+            <span className="ml-2 text-sm text-gray-700">
+              Professional Affiliate
+            </span>
           </label>
         </div>
       </div>
 
       <div>
-        <label htmlFor="sponsor_notes" className="block text-sm font-medium text-gray-700 mb-2">
+        <label
+          htmlFor="sponsor_notes"
+          className="block text-sm font-medium text-gray-700 mb-2"
+        >
           Sponsor Notes
         </label>
         <textarea

--- a/administration/client/src/features/MemberDetails/components/EmailModal.tsx
+++ b/administration/client/src/features/MemberDetails/components/EmailModal.tsx
@@ -1,0 +1,171 @@
+import { useState } from 'react';
+import { Modal } from '../../../components/Modal';
+import { Member } from '../../../types';
+
+interface EmailTemplate {
+  id: string;
+  name: string;
+  subject: string;
+  body: string;
+}
+
+interface EmailModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  member: Member | null;
+  onSendEmail: (subject: string, body: string) => void;
+}
+
+const emailTemplates: EmailTemplate[] = [
+  {
+    id: 'welcome',
+    name: 'Welcome Email',
+    subject: 'Welcome to Our Community!',
+    body: "Hi {{first_name}},\n\nWelcome to our community! We're excited to have you join us.\n\nLorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.\n\nBest regards,\nThe Team",
+  },
+  {
+    id: 'reminder',
+    name: 'Event Reminder',
+    subject: 'Upcoming Event Reminder',
+    body: 'Hello {{preferred_name || first_name}},\n\nThis is a friendly reminder about our upcoming event.\n\nLorem ipsum dolor sit amet, consectetur adipiscing elit. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris.\n\nSee you there!\nEvent Team',
+  },
+  {
+    id: 'follow_up',
+    name: 'Follow-up',
+    subject: 'Following up with you',
+    body: 'Dear {{first_name}},\n\nI wanted to follow up on our recent conversation.\n\nLorem ipsum dolor sit amet, consectetur adipiscing elit. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore.\n\nPlease let me know if you have any questions.\n\nBest,\nAdmin Team',
+  },
+];
+
+export function EmailModal({
+  isOpen,
+  onClose,
+  member,
+  onSendEmail,
+}: EmailModalProps) {
+  const [selectedTemplate, setSelectedTemplate] = useState('');
+  const [emailSubject, setEmailSubject] = useState('');
+  const [emailBody, setEmailBody] = useState('');
+
+  const handleTemplateSelect = (templateId: string) => {
+    setSelectedTemplate(templateId);
+    if (templateId) {
+      const template = emailTemplates.find((t) => t.id === templateId);
+      if (template) {
+        setEmailSubject(template.subject);
+        setEmailBody(template.body);
+      }
+    } else {
+      setEmailSubject('');
+      setEmailBody('');
+    }
+  };
+
+  const handleSendEmail = () => {
+    if (!member || !emailSubject.trim() || !emailBody.trim()) {
+      alert('Please fill in both subject and body fields.');
+      return;
+    }
+    onSendEmail(emailSubject, emailBody);
+    handleClose();
+  };
+
+  const handleClose = () => {
+    setSelectedTemplate('');
+    setEmailSubject('');
+    setEmailBody('');
+    onClose();
+  };
+
+  return (
+    <Modal isOpen={isOpen} onClose={handleClose} title="Send Email">
+      <div className="space-y-4">
+        <div>
+          <p className="text-sm text-gray-600 mb-3">
+            Send email to: <span className="font-medium">{member?.email}</span>
+          </p>
+          <label
+            htmlFor="emailTemplate"
+            className="block text-sm font-medium text-gray-700 mb-2"
+          >
+            Choose Template (Optional)
+          </label>
+          <select
+            id="emailTemplate"
+            value={selectedTemplate}
+            onChange={(e) => handleTemplateSelect(e.target.value)}
+            className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500"
+          >
+            <option value="">Write your own email...</option>
+            {emailTemplates.map((template) => (
+              <option key={template.id} value={template.id}>
+                {template.name}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <div>
+          <label
+            htmlFor="emailSubject"
+            className="block text-sm font-medium text-gray-700 mb-2"
+          >
+            Subject
+          </label>
+          <input
+            type="text"
+            id="emailSubject"
+            value={emailSubject}
+            onChange={(e) => setEmailSubject(e.target.value)}
+            className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500"
+            placeholder="Enter email subject..."
+          />
+        </div>
+
+        <div>
+          <label
+            htmlFor="emailBody"
+            className="block text-sm font-medium text-gray-700 mb-2"
+          >
+            Message
+          </label>
+          <textarea
+            id="emailBody"
+            rows={8}
+            value={emailBody}
+            onChange={(e) => setEmailBody(e.target.value)}
+            className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500"
+            placeholder="Write your email message here..."
+          />
+        </div>
+
+        <div className="bg-blue-50 p-3 rounded-md">
+          <h4 className="font-medium text-blue-900 mb-1">
+            Available Variables:
+          </h4>
+          <p className="text-sm text-blue-700">
+            You can use these placeholders: <code>{'{{first_name}}'}</code>,{' '}
+            <code>{'{{last_name}}'}</code>, <code>{'{{preferred_name}}'}</code>,{' '}
+            <code>{'{{email}}'}</code>
+          </p>
+        </div>
+
+        <div className="flex justify-end space-x-3">
+          <button
+            onClick={handleClose}
+            className="px-4 py-2 text-gray-700 bg-gray-200 rounded-md hover:bg-gray-300"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={handleSendEmail}
+            disabled={!emailSubject.trim() || !emailBody.trim()}
+            className="px-4 py-2 bg-green-600 text-white rounded-md hover:bg-green-700 disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            Send Email
+          </button>
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/administration/client/src/features/MemberDetails/components/InfoCards.tsx
+++ b/administration/client/src/features/MemberDetails/components/InfoCards.tsx
@@ -1,0 +1,82 @@
+import { Member } from '../../../types';
+import { StatusBadge } from './StatusBadge';
+
+interface InfoCardsProps {
+  member: Member;
+}
+
+export function InfoCards({ member }: InfoCardsProps) {
+  return (
+    <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+      {/* Basic Information */}
+      <div className="bg-white shadow rounded-lg p-6">
+        <h2 className="text-lg font-semibold text-gray-900 mb-4">
+          Basic Information
+        </h2>
+        <dl className="space-y-3">
+          <div>
+            <dt className="text-sm font-medium text-gray-500">Full Name</dt>
+            <dd className="text-sm text-gray-900">
+              {member.first_name} {member.last_name}
+            </dd>
+          </div>
+          {member.preferred_name && (
+            <div>
+              <dt className="text-sm font-medium text-gray-500">
+                Preferred Name
+              </dt>
+              <dd className="text-sm text-gray-900">{member.preferred_name}</dd>
+            </div>
+          )}
+          <div>
+            <dt className="text-sm font-medium text-gray-500">Email</dt>
+            <dd className="text-sm text-gray-900">{member.email}</dd>
+          </div>
+          {member.pronouns && (
+            <div>
+              <dt className="text-sm font-medium text-gray-500">Pronouns</dt>
+              <dd className="text-sm text-gray-900">{member.pronouns}</dd>
+            </div>
+          )}
+          <div>
+            <dt className="text-sm font-medium text-gray-500">Status</dt>
+            <dd className="text-sm text-gray-900">
+              <StatusBadge member={member} />
+            </dd>
+          </div>
+          <div>
+            <dt className="text-sm font-medium text-gray-500">Member Since</dt>
+            <dd className="text-sm text-gray-900">
+              {new Date(member.created_at).toLocaleDateString()}
+            </dd>
+          </div>
+        </dl>
+      </div>
+
+      {/* Additional Information */}
+      <div className="bg-white shadow rounded-lg p-6">
+        <h2 className="text-lg font-semibold text-gray-900 mb-4">
+          Additional Information
+        </h2>
+        <dl className="space-y-3">
+          {member.sponsor_notes && (
+            <div>
+              <dt className="text-sm font-medium text-gray-500">
+                Sponsor Notes
+              </dt>
+              <dd className="text-sm text-gray-900 whitespace-pre-wrap">
+                {member.sponsor_notes}
+              </dd>
+            </div>
+          )}
+          <div>
+            <dt className="text-sm font-medium text-gray-500">Last Updated</dt>
+            <dd className="text-sm text-gray-900">
+              {new Date(member.updated_at).toLocaleDateString()}
+            </dd>
+          </div>
+        </dl>
+      </div>
+    </div>
+  );
+}

--- a/administration/client/src/features/MemberDetails/components/LoadingStates.tsx
+++ b/administration/client/src/features/MemberDetails/components/LoadingStates.tsx
@@ -1,0 +1,56 @@
+import { useNavigate } from 'react-router-dom';
+
+interface LoadingStatesProps {
+  isLoading: boolean;
+  error: any;
+}
+
+export function LoadingStates({ isLoading, error }: LoadingStatesProps) {
+  const navigate = useNavigate();
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center min-h-96">
+        <div className="text-gray-500">Loading member details...</div>
+      </div>
+    );
+  }
+
+  if (error) {
+    // Check if it's a 403 Unauthorized error
+    const is403Error =
+      error &&
+      typeof error === 'object' &&
+      'response' in error &&
+      (error as any).response?.status === 403;
+
+    return (
+      <div className="text-center py-12">
+        <div className="text-red-600 mb-4">
+          {is403Error
+            ? "You don't have permission to access this member's details"
+            : 'Failed to load member details'}
+        </div>
+        <div className="space-x-4">
+          <button
+            onClick={() => navigate(is403Error ? '/dashboard' : '/members')}
+            className="bg-blue-600 text-white px-4 py-2 rounded-md hover:bg-blue-700"
+            data-testid="back-to-members-btn"
+          >
+            {is403Error ? 'Go to Dashboard' : 'Back to Members'}
+          </button>
+          {!is403Error && (
+            <button
+              onClick={() => window.location.reload()}
+              className="bg-gray-600 text-white px-4 py-2 rounded-md hover:bg-gray-700"
+            >
+              Retry
+            </button>
+          )}
+        </div>
+      </div>
+    );
+  }
+
+  return null;
+}

--- a/administration/client/src/features/MemberDetails/components/StatusBadge.tsx
+++ b/administration/client/src/features/MemberDetails/components/StatusBadge.tsx
@@ -1,0 +1,38 @@
+import { Member } from '../../../types';
+import {
+  getAccessLevelColor,
+  getAccessLevelName,
+} from '../../../utils/authorization';
+
+interface StatusBadgeProps {
+  member: Member;
+}
+
+export function StatusBadge({ member }: StatusBadgeProps) {
+  const isActive = member.flags & 1;
+  const isProfessional = member.flags & 2;
+
+  return (
+    <div className="flex flex-wrap gap-1">
+      <span
+        className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${
+          isActive ? 'bg-green-100 text-green-800' : 'bg-red-100 text-red-800'
+        }`}
+      >
+        {isActive ? 'Active' : 'Inactive'}
+      </span>
+      {isProfessional && (
+        <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-blue-100 text-blue-800">
+          Professional
+        </span>
+      )}
+      <span
+        className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${getAccessLevelColor(
+          member.access_level || 1
+        )}`}
+      >
+        {getAccessLevelName(member.access_level || 1)}
+      </span>
+    </div>
+  );
+}

--- a/administration/client/src/features/MemberDetails/components/index.ts
+++ b/administration/client/src/features/MemberDetails/components/index.ts
@@ -1,0 +1,7 @@
+export * from './ApplicationNotes';
+export * from './AuditHistory';
+export * from './EditMemberForm';
+export * from './EmailModal';
+export * from './InfoCards';
+export * from './LoadingStates';
+export * from './StatusBadge';

--- a/administration/client/src/features/Members/components/MemberFormModal.tsx
+++ b/administration/client/src/features/Members/components/MemberFormModal.tsx
@@ -1,0 +1,34 @@
+import { Modal } from '../../../components/Modal';
+import { Member, MemberFormData } from '../../../types';
+import { EditMemberForm } from '../../MemberDetails/components/EditMemberForm';
+
+interface MemberFormModalProps {
+  isOpen: boolean;
+  editingMember: Member | null;
+  onSubmit: (formData: MemberFormData) => Promise<void>;
+  onClose: () => void;
+  isLoading: boolean;
+}
+
+export function MemberFormModal({
+  isOpen,
+  editingMember,
+  onSubmit,
+  onClose,
+  isLoading,
+}: MemberFormModalProps) {
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={onClose}
+      title={editingMember ? 'Edit Member' : 'Add New Member'}
+    >
+      <EditMemberForm
+        member={editingMember || undefined}
+        onSubmit={onSubmit}
+        onCancel={onClose}
+        isLoading={isLoading}
+      />
+    </Modal>
+  );
+}

--- a/administration/client/src/features/Members/components/MemberGrid.tsx
+++ b/administration/client/src/features/Members/components/MemberGrid.tsx
@@ -1,0 +1,94 @@
+import { Member } from '../../../types';
+import { MemberTableRow } from './MemberTableRow';
+
+interface MemberGridProps {
+  members: Member[];
+  isLoading: boolean;
+  onEdit: (member: Member) => void;
+  onDelete: (member: Member) => void;
+  isEditPending: boolean;
+  isDeletePending: boolean;
+  children?: React.ReactNode;
+  searchTerm: string;
+  onSearchChange: (value: string) => void;
+}
+
+export function MemberGrid({
+  members,
+  isLoading,
+  onEdit,
+  onDelete,
+  isEditPending,
+  isDeletePending,
+  children,
+  searchTerm,
+  onSearchChange,
+}: MemberGridProps) {
+  return (
+    <div className="bg-white shadow rounded-lg overflow-hidden">
+      <div className="p-6 border-b border-gray-200">
+        <div className="flex items-center space-x-4">
+          <div className="flex-1">
+            <input
+              type="text"
+              placeholder="Search members..."
+              value={searchTerm}
+              onChange={(e) => onSearchChange(e.target.value)}
+              className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+            />
+          </div>
+        </div>
+      </div>
+      <div className="overflow-x-auto">
+        <table className="min-w-full divide-y divide-gray-200">
+          <thead className="bg-gray-50">
+            <tr>
+              <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                Name
+              </th>
+              <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                Email
+              </th>
+              <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                Pronouns
+              </th>
+              <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                Status
+              </th>
+              <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                Actions
+              </th>
+            </tr>
+          </thead>
+          <tbody className="bg-white divide-y divide-gray-200">
+            {isLoading ? (
+              <tr>
+                <td colSpan={5} className="px-6 py-4 text-center text-gray-500">
+                  Loading members...
+                </td>
+              </tr>
+            ) : members.length === 0 ? (
+              <tr>
+                <td colSpan={5} className="px-6 py-4 text-center text-gray-500">
+                  No members found. Start by adding your first member!
+                </td>
+              </tr>
+            ) : (
+              members.map((member) => (
+                <MemberTableRow
+                  key={member.id}
+                  member={member}
+                  onEdit={onEdit}
+                  onDelete={onDelete}
+                  isEditPending={isEditPending}
+                  isDeletePending={isDeletePending}
+                />
+              ))
+            )}
+          </tbody>
+        </table>
+      </div>
+      {children}
+    </div>
+  );
+}

--- a/administration/client/src/features/Members/components/MemberPagination.tsx
+++ b/administration/client/src/features/Members/components/MemberPagination.tsx
@@ -1,0 +1,41 @@
+interface MemberPaginationProps {
+  currentPage: number;
+  totalPages: number;
+  isLoading: boolean;
+  onPageChange: (page: number) => void;
+}
+
+export function MemberPagination({
+  currentPage,
+  totalPages,
+  isLoading,
+  onPageChange,
+}: MemberPaginationProps) {
+  if (totalPages <= 1) {
+    return null;
+  }
+
+  return (
+    <div className="px-6 py-3 border-t border-gray-200">
+      <div className="flex justify-between items-center">
+        <button
+          onClick={() => onPageChange(Math.max(1, currentPage - 1))}
+          disabled={currentPage === 1 || isLoading}
+          className="px-3 py-1 text-sm bg-gray-200 text-gray-700 rounded disabled:opacity-50"
+        >
+          Previous
+        </button>
+        <span className="text-sm text-gray-700">
+          Page {currentPage} of {totalPages}
+        </span>
+        <button
+          onClick={() => onPageChange(Math.min(totalPages, currentPage + 1))}
+          disabled={currentPage === totalPages || isLoading}
+          className="px-3 py-1 text-sm bg-gray-200 text-gray-700 rounded disabled:opacity-50"
+        >
+          Next
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/administration/client/src/features/Members/components/MemberStatusBadge.tsx
+++ b/administration/client/src/features/Members/components/MemberStatusBadge.tsx
@@ -1,0 +1,25 @@
+interface MemberStatusBadgeProps {
+  flags: number;
+}
+
+export function MemberStatusBadge({ flags }: MemberStatusBadgeProps) {
+  const isActive = flags & 1;
+  const isProfessional = flags & 2;
+
+  return (
+    <div className="flex space-x-1">
+      <span
+        className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${
+          isActive ? 'bg-green-100 text-green-800' : 'bg-red-100 text-red-800'
+        }`}
+      >
+        {isActive ? 'Active' : 'Inactive'}
+      </span>
+      {isProfessional ? (
+        <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-blue-100 text-blue-800">
+          Professional
+        </span>
+      ) : null}
+    </div>
+  );
+}

--- a/administration/client/src/features/Members/components/MemberTableRow.tsx
+++ b/administration/client/src/features/Members/components/MemberTableRow.tsx
@@ -1,0 +1,77 @@
+import { PencilIcon, TrashIcon } from '@heroicons/react/24/outline';
+import { Link } from 'react-router-dom';
+import { Member } from '../../../types';
+import { MemberStatusBadge } from './MemberStatusBadge';
+
+interface MemberTableRowProps {
+  member: Member;
+  onEdit: (member: Member) => void;
+  onDelete: (member: Member) => void;
+  isEditPending: boolean;
+  isDeletePending: boolean;
+}
+
+export function MemberTableRow({
+  member,
+  onEdit,
+  onDelete,
+  isEditPending,
+  isDeletePending,
+}: MemberTableRowProps) {
+  const getDisplayName = () => {
+    return member.preferred_name
+      ? `${member.preferred_name} (${member.first_name}) ${member.last_name}`
+      : `${member.first_name} ${member.last_name}`;
+  };
+
+  const handleDelete = () => {
+    if (
+      !confirm(
+        `Are you sure you want to delete ${member.first_name} ${member.last_name}?`
+      )
+    ) {
+      return;
+    }
+    onDelete(member);
+  };
+
+  return (
+    <tr className="hover:bg-gray-50">
+      <td className="px-6 py-4 whitespace-nowrap">
+        <Link
+          to={`/members/${member.id}`}
+          className="text-sm font-medium text-blue-600 hover:text-blue-900"
+        >
+          {getDisplayName()}
+        </Link>
+      </td>
+      <td className="px-6 py-4 whitespace-nowrap">
+        <div className="text-sm text-gray-900">{member.email}</div>
+      </td>
+      <td className="px-6 py-4 whitespace-nowrap">
+        <div className="text-sm text-gray-900">{member.pronouns || '-'}</div>
+      </td>
+      <td className="px-6 py-4 whitespace-nowrap">
+        <MemberStatusBadge flags={member.flags} />
+      </td>
+      <td className="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
+        <div className="flex space-x-2">
+          <button
+            onClick={() => onEdit(member)}
+            disabled={isEditPending}
+            className="text-blue-600 hover:text-blue-900 disabled:opacity-50"
+          >
+            <PencilIcon className="h-4 w-4" />
+          </button>
+          <button
+            onClick={handleDelete}
+            disabled={isDeletePending}
+            className="text-red-600 hover:text-red-900 disabled:opacity-50"
+          >
+            <TrashIcon className="h-4 w-4" />
+          </button>
+        </div>
+      </td>
+    </tr>
+  );
+}

--- a/administration/client/src/features/Members/components/index.ts
+++ b/administration/client/src/features/Members/components/index.ts
@@ -1,0 +1,5 @@
+export { MemberFormModal } from './MemberFormModal';
+export { MemberGrid } from './MemberGrid';
+export { MemberPagination } from './MemberPagination';
+export { MemberStatusBadge } from './MemberStatusBadge';
+export { MemberTableRow } from './MemberTableRow';

--- a/administration/client/src/features/Members/hooks/useMemberCrud.tsx
+++ b/administration/client/src/features/Members/hooks/useMemberCrud.tsx
@@ -1,0 +1,87 @@
+import { useState } from 'react';
+import {
+  useCreateMember,
+  useDeleteMember,
+  useUpdateMember,
+} from '../../../hooks/useMembers';
+import { Member, MemberFormData } from '../../../types';
+
+export function useMemberCrud() {
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [editingMember, setEditingMember] = useState<Member | null>(null);
+
+  const createMember = useCreateMember();
+  const updateMember = useUpdateMember();
+  const deleteMember = useDeleteMember();
+
+  const handleCreateMember = () => {
+    setEditingMember(null);
+    setIsModalOpen(true);
+  };
+
+  const handleEditMember = (member: Member) => {
+    setEditingMember(member);
+    setIsModalOpen(true);
+  };
+
+  const handleDeleteMember = async (member: Member) => {
+    try {
+      await deleteMember.mutateAsync(member.id);
+    } catch (error) {
+      console.error('Failed to delete member:', error);
+      alert('Failed to delete member. Please try again.');
+    }
+  };
+
+  const handleFormSubmit = async (formData: MemberFormData) => {
+    try {
+      if (editingMember) {
+        await updateMember.mutateAsync({
+          id: editingMember.id,
+          first_name: formData.first_name,
+          last_name: formData.last_name,
+          preferred_name: formData.preferred_name || '',
+          email: formData.email,
+          pronouns: formData.pronouns || '',
+          sponsor_notes: formData.sponsor_notes || '',
+          is_professional_affiliate: formData.is_professional_affiliate,
+        });
+      } else {
+        await createMember.mutateAsync({
+          first_name: formData.first_name,
+          last_name: formData.last_name,
+          preferred_name: formData.preferred_name || '',
+          email: formData.email,
+          pronouns: formData.pronouns || '',
+          sponsor_notes: formData.sponsor_notes || '',
+          is_professional_affiliate: formData.is_professional_affiliate,
+        });
+      }
+
+      setIsModalOpen(false);
+      setEditingMember(null);
+    } catch (error) {
+      console.error('Failed to save member:', error);
+      alert('Failed to save member. Please try again.');
+    }
+  };
+
+  const closeModal = () => {
+    setIsModalOpen(false);
+    setEditingMember(null);
+  };
+
+  return {
+    isModalOpen,
+    editingMember,
+    handleCreateMember,
+    handleEditMember,
+    handleDeleteMember,
+    handleFormSubmit,
+    closeModal,
+    isCreatePending: createMember.isPending,
+    isUpdatePending: updateMember.isPending,
+    isDeletePending: deleteMember.isPending,
+    isFormLoading: createMember.isPending || updateMember.isPending,
+  };
+}

--- a/administration/client/src/features/Members/hooks/useMemberCsvImport.tsx
+++ b/administration/client/src/features/Members/hooks/useMemberCsvImport.tsx
@@ -1,0 +1,53 @@
+import { useState } from 'react';
+import { ApplicationFormData } from '../../../types';
+
+export function useMemberCsvImport() {
+  const [csvImportLoading, setCsvImportLoading] = useState(false);
+
+  const handleCsvImport = async (applications: ApplicationFormData[]) => {
+    setCsvImportLoading(true);
+
+    try {
+      const response = await fetch('/api/applications/bulk', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ applications }),
+      });
+
+      const result = await response.json();
+
+      if (response.ok || response.status === 207) {
+        const { imported, total, errors } = result.data;
+
+        if (errors && errors.length > 0) {
+          const errorDetails = errors
+            .map(
+              (err: any) =>
+                `Row ${err.index}: ${err.email || 'Unknown'} - ${err.error}`
+            )
+            .join('\n');
+
+          alert(
+            `Import completed with some errors:\n\nImported: ${imported}/${total}\n\nErrors:\n${errorDetails}`
+          );
+        } else {
+          alert(`Successfully imported all ${imported} applications!`);
+        }
+      } else {
+        throw new Error(result.error || 'Failed to import applications');
+      }
+    } catch (error) {
+      console.error('Error importing applications:', error);
+      alert('Failed to import applications. Please try again.');
+    } finally {
+      setCsvImportLoading(false);
+    }
+  };
+
+  return {
+    handleCsvImport,
+    isCsvImportLoading: csvImportLoading,
+  };
+}

--- a/administration/client/src/hooks/useEvents.ts
+++ b/administration/client/src/hooks/useEvents.ts
@@ -1,6 +1,6 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { api } from '@/lib/api';
-import { Event, CreateEventRequest, UpdateEventRequest } from '@/types';
+import { Event, CreateEventRequest, UpdateEventRequest, EventWithDetails } from '@/types';
 
 interface EventsResponse {
   success: boolean;
@@ -23,6 +23,8 @@ const eventKeys = {
   all: ['events'] as const,
   lists: () => [...eventKeys.all, 'list'] as const,
   list: (params: GetEventsParams) => [...eventKeys.lists(), params] as const,
+  details: () => [...eventKeys.all, 'details'] as const,
+  detail: (id: number) => [...eventKeys.details(), id] as const,
 };
 
 export function useEvents(params: GetEventsParams = {}) {
@@ -37,6 +39,18 @@ export function useEvents(params: GetEventsParams = {}) {
       events: data.data,
       pagination: data.pagination,
     }),
+  });
+}
+
+export function useEventDetails(id: number, enabled: boolean = true) {
+  return useQuery({
+    queryKey: eventKeys.detail(id),
+    queryFn: async (): Promise<EventWithDetails> => {
+      const response = await api.get(`/events/${id}/details`);
+      return response.data.data;
+    },
+    enabled: enabled && id > 0,
+    staleTime: 5 * 60 * 1000, // 5 minutes
   });
 }
 

--- a/administration/client/src/pages/EventDetails.tsx
+++ b/administration/client/src/pages/EventDetails.tsx
@@ -1,407 +1,92 @@
-import { useState, useEffect } from 'react';
-import { useParams, useNavigate } from 'react-router-dom';
-import { ArrowLeftIcon, PencilIcon } from '@heroicons/react/24/outline';
-import { EventService } from '../services/eventService';
-import { EventWithDetails, Member, CreateEventMarketingRequest, CreateVolunteerRequest } from '../types';
+import { useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
 import { EventMarketingForm } from '../components/EventMarketingForm';
 import { EventVolunteersManager } from '../components/EventVolunteersManager';
 import { Modal } from '../components/Modal';
+import {
+  Attendance,
+  Header,
+  LoadingStates,
+  Marketing,
+  Overview,
+  Tabs,
+} from '../features/EventDetails/components';
+import { useEventCrud } from '../features/EventDetails/hooks/useEventCrud';
+import { useEventDetails } from '../hooks/useEvents';
+import { useMembers } from '../hooks/useMembers';
 
 export function EventDetails() {
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
-  const [eventDetails, setEventDetails] = useState<EventWithDetails | null>(null);
-  const [members, setMembers] = useState<Member[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [activeTab, setActiveTab] = useState<'overview' | 'marketing' | 'volunteers' | 'attendance'>('overview');
+  const [activeTab, setActiveTab] = useState<
+    'overview' | 'marketing' | 'volunteers' | 'attendance'
+  >('overview');
   const [showMarketingForm, setShowMarketingForm] = useState(false);
-  const [marketingLoading, setMarketingLoading] = useState(false);
-  const [volunteerLoading, setVolunteerLoading] = useState(false);
 
-  const eventId = id ? parseInt(id, 10) : 0;
+  const eventId = parseInt(id || '0', 10);
+  const {
+    data: eventDetails,
+    isLoading,
+    error,
+  } = useEventDetails(eventId, !!id);
+  const { data: membersData } = useMembers({ limit: 100 });
+  const members = membersData?.members || [];
 
-  useEffect(() => {
-    if (eventId) {
-      fetchEventDetails();
-      fetchMembers();
-    }
-  }, [eventId]);
+  const {
+    handleMarketingSubmit,
+    handleVolunteerSubmit,
+    marketingLoading,
+    volunteerLoading,
+  } = useEventCrud(eventId);
 
-  const fetchEventDetails = async () => {
-    try {
-      setLoading(true);
-      const response = await EventService.getEventWithDetails(eventId);
-      if (response.success && response.data) {
-        setEventDetails(response.data);
-      }
-    } catch (error) {
-      console.error('Failed to fetch event details:', error);
-    } finally {
-      setLoading(false);
-    }
-  };
-
-  const fetchMembers = async () => {
-    try {
-      const response = await fetch('/api/members?limit=100');
-      if (response.ok) {
-        const data = await response.json();
-        setMembers(data.data || []);
-      }
-    } catch (error) {
-      console.error('Failed to fetch members:', error);
-    }
-  };
-
-  const handleMarketingSubmit = async (data: CreateEventMarketingRequest) => {
-    try {
-      setMarketingLoading(true);
-      await EventService.createEventMarketing(eventId, data);
-      setShowMarketingForm(false);
-      await fetchEventDetails();
-    } catch (error) {
-      console.error('Failed to save marketing:', error);
-      alert('Failed to save marketing content. Please try again.');
-    } finally {
-      setMarketingLoading(false);
-    }
-  };
-
-  const handleVolunteerSubmit = async (data: CreateVolunteerRequest) => {
-    try {
-      setVolunteerLoading(true);
-      await EventService.addVolunteer(eventId, data);
-      await fetchEventDetails();
-    } catch (error) {
-      console.error('Failed to add volunteer:', error);
-      alert('Failed to add volunteer. Please try again.');
-    } finally {
-      setVolunteerLoading(false);
-    }
-  };
-
-  const formatDateTime = (dateTime: string) => {
-    return new Date(dateTime).toLocaleString();
-  };
-
-  const getEventStatus = () => {
-    if (!eventDetails) return 'unknown';
-    const now = new Date();
-    const start = new Date(eventDetails.event.start_datetime);
-    const end = new Date(eventDetails.event.end_datetime);
-    
-    if (now < start) return 'upcoming';
-    if (now >= start && now <= end) return 'ongoing';
-    return 'past';
-  };
-
-  const getStatusBadge = () => {
-    const status = getEventStatus();
-    const isActive = eventDetails ? eventDetails.event.flags & 1 : false;
-    const isPublic = eventDetails ? eventDetails.event.flags & 2 : false;
-    
-    return (
-      <div className="flex space-x-2">
-        <span className={`inline-flex items-center px-3 py-1 rounded-full text-sm font-medium ${
-          status === 'upcoming' ? 'bg-blue-100 text-blue-800' :
-          status === 'ongoing' ? 'bg-green-100 text-green-800' :
-          'bg-gray-100 text-gray-800'
-        }`}>
-          {status === 'upcoming' ? 'Upcoming' :
-           status === 'ongoing' ? 'Ongoing' : 'Past'}
-        </span>
-        {isPublic && (
-          <span className="inline-flex items-center px-3 py-1 rounded-full text-sm font-medium bg-purple-100 text-purple-800">
-            Public
-          </span>
-        )}
-        {!isActive && (
-          <span className="inline-flex items-center px-3 py-1 rounded-full text-sm font-medium bg-red-100 text-red-800">
-            Inactive
-          </span>
-        )}
-      </div>
-    );
-  };
-
-  if (loading) {
-    return (
-      <div className="flex justify-center items-center h-64">
-        <div className="text-gray-500">Loading event details...</div>
-      </div>
-    );
-  }
-
-  if (!eventDetails) {
-    return (
-      <div className="text-center py-12">
-        <h2 className="text-2xl font-semibold text-gray-900 mb-4">Event not found</h2>
-        <button
-          onClick={() => navigate('/events')}
-          className="text-blue-600 hover:text-blue-500"
-        >
-          ← Back to Events
-        </button>
-      </div>
-    );
+  if (isLoading || error || !eventDetails) {
+    return <LoadingStates isLoading={isLoading} error={error} />;
   }
 
   const { event, marketing, volunteers, attendance } = eventDetails;
 
   return (
     <div className="max-w-7xl mx-auto">
-      {/* Header */}
-      <div className="mb-6">
-        <div className="flex items-center justify-between mb-4">
-          <button
-            onClick={() => navigate('/events')}
-            className="flex items-center text-gray-600 hover:text-gray-900"
-          >
-            <ArrowLeftIcon className="h-5 w-5 mr-2" />
-            Back to Events
-          </button>
-        </div>
-        
-        <div className="bg-white shadow rounded-lg p-6">
-          <div className="flex justify-between items-start mb-4">
-            <div>
-              <h1 className="text-3xl font-bold text-gray-900 mb-2">{event.name}</h1>
-              {event.description && (
-                <p className="text-gray-600 mb-4">{event.description}</p>
-              )}
-              {getStatusBadge()}
-            </div>
-            <button 
-              onClick={() => navigate('/events', { state: { editEventId: eventDetails.event.id } })}
-              className="flex items-center px-4 py-2 border border-gray-300 rounded-md text-gray-700 hover:bg-gray-50"
-            >
-              <PencilIcon className="h-4 w-4 mr-2" />
-              Edit Event
-            </button>
-          </div>
+      <Header
+        event={event}
+        eventDetails={eventDetails}
+        onBack={() => navigate('/events')}
+        onEdit={() => navigate('/events', { state: { editEventId: event.id } })}
+      />
 
-          <div className="grid grid-cols-1 md:grid-cols-3 gap-6 text-sm">
-            <div>
-              <span className="font-medium text-gray-700">Start:</span>
-              <div className="text-gray-900">{formatDateTime(event.start_datetime)}</div>
-            </div>
-            <div>
-              <span className="font-medium text-gray-700">End:</span>
-              <div className="text-gray-900">{formatDateTime(event.end_datetime)}</div>
-            </div>
-            <div>
-              <span className="font-medium text-gray-700">Capacity:</span>
-              <div className="text-gray-900">{event.max_capacity || 'Unlimited'}</div>
-            </div>
-          </div>
+      <Tabs
+        activeTab={activeTab}
+        onTabChange={setActiveTab}
+        volunteersCount={volunteers.length}
+        attendanceCount={attendance.length}
+      >
+        {activeTab === 'overview' && (
+          <Overview
+            eventDetails={eventDetails}
+            volunteers={volunteers}
+            attendance={attendance}
+          />
+        )}
 
-          {eventDetails.eventbrite_link && (
-            <div className="mt-4 p-3 bg-blue-50 rounded-md">
-              <span className="text-blue-800 font-medium">Eventbrite Integration:</span>
-              <span className="text-blue-700 ml-2">
-                Sync Status: {eventDetails.eventbrite_link.sync_status}
-              </span>
-            </div>
-          )}
-        </div>
-      </div>
+        {activeTab === 'marketing' && (
+          <Marketing
+            marketing={marketing}
+            onEditMarketing={() => setShowMarketingForm(true)}
+          />
+        )}
 
-      {/* Tabs */}
-      <div className="bg-white shadow rounded-lg">
-        <div className="border-b border-gray-200">
-          <nav className="flex space-x-8 px-6">
-            {[
-              { key: 'overview', label: 'Overview' },
-              { key: 'marketing', label: 'Marketing' },
-              { key: 'volunteers', label: `Volunteers (${volunteers.length})` },
-              { key: 'attendance', label: `Attendance (${attendance.length})` }
-            ].map((tab) => (
-              <button
-                key={tab.key}
-                onClick={() => setActiveTab(tab.key as any)}
-                className={`py-4 px-1 border-b-2 font-medium text-sm ${
-                  activeTab === tab.key
-                    ? 'border-blue-500 text-blue-600'
-                    : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300'
-                }`}
-              >
-                {tab.label}
-              </button>
-            ))}
-          </nav>
-        </div>
+        {activeTab === 'volunteers' && (
+          <EventVolunteersManager
+            eventId={eventId}
+            volunteers={volunteers}
+            members={members}
+            onAddVolunteer={handleVolunteerSubmit}
+            isLoading={volunteerLoading}
+          />
+        )}
 
-        <div className="p-6">
-          {/* Overview Tab */}
-          {activeTab === 'overview' && (
-            <div className="space-y-6">
-              <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-                <div className="bg-gray-50 p-4 rounded-md">
-                  <h3 className="font-medium text-gray-900 mb-2">Event Statistics</h3>
-                  <dl className="space-y-2 text-sm">
-                    <div className="flex justify-between">
-                      <dt className="text-gray-600">Total Registrations:</dt>
-                      <dd className="font-medium">{attendance.length}</dd>
-                    </div>
-                    <div className="flex justify-between">
-                      <dt className="text-gray-600">Volunteers:</dt>
-                      <dd className="font-medium">{volunteers.length}</dd>
-                    </div>
-                    <div className="flex justify-between">
-                      <dt className="text-gray-600">Checked In:</dt>
-                      <dd className="font-medium">
-                        {attendance.filter(a => a.check_in_method).length}
-                      </dd>
-                    </div>
-                  </dl>
-                </div>
-
-                {eventDetails.eventbrite_event && (
-                  <div className="bg-gray-50 p-4 rounded-md">
-                    <h3 className="font-medium text-gray-900 mb-2">Eventbrite Info</h3>
-                    <dl className="space-y-2 text-sm">
-                      <div className="flex justify-between">
-                        <dt className="text-gray-600">Capacity:</dt>
-                        <dd className="font-medium">{eventDetails.eventbrite_event.capacity || 'N/A'}</dd>
-                      </div>
-                      <div className="flex justify-between">
-                        <dt className="text-gray-600">Last Synced:</dt>
-                        <dd className="font-medium">
-                          {new Date(eventDetails.eventbrite_event.last_synced_at).toLocaleString()}
-                        </dd>
-                      </div>
-                    </dl>
-                  </div>
-                )}
-              </div>
-            </div>
-          )}
-
-          {/* Marketing Tab */}
-          {activeTab === 'marketing' && (
-            <div>
-              {marketing ? (
-                <div className="space-y-6">
-                  <div className="flex justify-between items-center">
-                    <h3 className="text-lg font-medium">Marketing Content</h3>
-                    <button
-                      onClick={() => setShowMarketingForm(true)}
-                      className="px-4 py-2 bg-blue-500 text-white rounded-md hover:bg-blue-600"
-                    >
-                      Edit Marketing
-                    </button>
-                  </div>
-                  
-                  <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-                    <div>
-                      <h4 className="font-medium text-gray-900 mb-2">Primary Copy</h4>
-                      <p className="text-gray-700 text-sm">{marketing.primary_marketing_copy || 'Not set'}</p>
-                    </div>
-                    <div>
-                      <h4 className="font-medium text-gray-900 mb-2">Blurb</h4>
-                      <p className="text-gray-700 text-sm">{marketing.blurb || 'Not set'}</p>
-                    </div>
-                    <div>
-                      <h4 className="font-medium text-gray-900 mb-2">Social Media Copy</h4>
-                      <p className="text-gray-700 text-sm">{marketing.social_media_copy || 'Not set'}</p>
-                    </div>
-                    <div>
-                      <h4 className="font-medium text-gray-900 mb-2">Email Subject</h4>
-                      <p className="text-gray-700 text-sm">{marketing.email_subject || 'Not set'}</p>
-                    </div>
-                  </div>
-                </div>
-              ) : (
-                <div className="text-center py-12">
-                  <h3 className="text-lg font-medium text-gray-900 mb-4">No marketing content yet</h3>
-                  <button
-                    onClick={() => setShowMarketingForm(true)}
-                    className="px-4 py-2 bg-blue-500 text-white rounded-md hover:bg-blue-600"
-                  >
-                    Add Marketing Content
-                  </button>
-                </div>
-              )}
-            </div>
-          )}
-
-          {/* Volunteers Tab */}
-          {activeTab === 'volunteers' && (
-            <EventVolunteersManager
-              eventId={eventId}
-              volunteers={volunteers}
-              members={members}
-              onAddVolunteer={handleVolunteerSubmit}
-              isLoading={volunteerLoading}
-            />
-          )}
-
-          {/* Attendance Tab */}
-          {activeTab === 'attendance' && (
-            <div>
-              <h3 className="text-lg font-medium mb-4">Event Attendance</h3>
-              
-              {attendance.length === 0 ? (
-                <p className="text-gray-500 text-center py-8">No attendance records yet.</p>
-              ) : (
-                <div className="overflow-x-auto">
-                  <table className="min-w-full divide-y divide-gray-200">
-                    <thead className="bg-gray-50">
-                      <tr>
-                        <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                          Member
-                        </th>
-                        <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                          Ticket Type
-                        </th>
-                        <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                          Registration
-                        </th>
-                        <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                          Check-in Status
-                        </th>
-                      </tr>
-                    </thead>
-                    <tbody className="bg-white divide-y divide-gray-200">
-                      {attendance.map((record) => (
-                        <tr key={record.id}>
-                          <td className="px-6 py-4 whitespace-nowrap">
-                            <div className="text-sm font-medium text-gray-900">
-                              {record.member_id ? `Member ${record.member_id}` : 'Non-member'}
-                            </div>
-                            {record.eventbrite_attendee_id && (
-                              <div className="text-sm text-gray-500">
-                                Eventbrite: {record.eventbrite_attendee_id}
-                              </div>
-                            )}
-                          </td>
-                          <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
-                            {record.ticket_type || 'N/A'}
-                          </td>
-                          <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
-                            {record.registration_date ? formatDateTime(record.registration_date) : 'N/A'}
-                          </td>
-                          <td className="px-6 py-4 whitespace-nowrap">
-                            {record.check_in_method ? (
-                              <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-green-100 text-green-800">
-                                Checked In ({record.check_in_method})
-                              </span>
-                            ) : (
-                              <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-yellow-100 text-yellow-800">
-                                Not Checked In
-                              </span>
-                            )}
-                          </td>
-                        </tr>
-                      ))}
-                    </tbody>
-                  </table>
-                </div>
-              )}
-            </div>
-          )}
-        </div>
-      </div>
+        {activeTab === 'attendance' && <Attendance attendance={attendance} />}
+      </Tabs>
 
       {/* Marketing Form Modal */}
       <Modal
@@ -412,12 +97,25 @@ export function EventDetails() {
       >
         <EventMarketingForm
           eventId={eventId}
-          initialData={marketing ? {
-            ...marketing,
-            hashtags: marketing.hashtags ? marketing.hashtags.split(',').map(tag => tag.trim()) : undefined,
-            key_selling_points: marketing.key_selling_points ? marketing.key_selling_points.split(',').map(point => point.trim()) : undefined
-          } : undefined}
-          onSubmit={handleMarketingSubmit}
+          initialData={
+            marketing
+              ? {
+                  ...marketing,
+                  hashtags: marketing.hashtags
+                    ? marketing.hashtags.split(',').map((tag) => tag.trim())
+                    : undefined,
+                  key_selling_points: marketing.key_selling_points
+                    ? marketing.key_selling_points
+                        .split(',')
+                        .map((point) => point.trim())
+                    : undefined,
+                }
+              : undefined
+          }
+          onSubmit={async (data) => {
+            await handleMarketingSubmit(data);
+            setShowMarketingForm(false);
+          }}
           onCancel={() => setShowMarketingForm(false)}
           isLoading={marketingLoading}
         />

--- a/administration/client/src/pages/Events.tsx
+++ b/administration/client/src/pages/Events.tsx
@@ -1,7 +1,11 @@
 import { PlusIcon } from '@heroicons/react/24/outline';
 import { useEffect, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
-import { EventFormModal, EventGrid } from '../features/Events/components';
+import {
+  EventFormModal,
+  EventGrid,
+  EventTableRow,
+} from '../features/Events/components';
 import { useEventCrud } from '../features/Events/hooks/useEventCrud';
 import { useEvents } from '../hooks/useEvents';
 import { Event } from '../types';
@@ -74,17 +78,24 @@ export function Events() {
       <EventGrid
         events={events}
         isLoading={loading}
-        onEdit={(event) => {
-          setEditingEvent(event);
-          setIsModalOpen(true);
-        }}
-        onDelete={handleDeleteEvent}
-        onView={handleViewEvent}
-        isEditPending={false}
-        isDeletePending={false}
         filter={filter}
         onFilterChange={setFilter}
-      />
+      >
+        {events.map((event) => (
+          <EventTableRow
+            key={event.id}
+            event={event}
+            onEdit={(event) => {
+              setEditingEvent(event);
+              setIsModalOpen(true);
+            }}
+            onDelete={handleDeleteEvent}
+            onView={handleViewEvent}
+            isEditPending={false}
+            isDeletePending={false}
+          />
+        ))}
+      </EventGrid>
 
       <EventFormModal
         isOpen={isModalOpen}

--- a/administration/client/src/pages/Events.tsx
+++ b/administration/client/src/pages/Events.tsx
@@ -1,10 +1,10 @@
-import { useState, useEffect } from 'react';
-import { useNavigate, useLocation } from 'react-router-dom';
-import { PlusIcon, PencilIcon, TrashIcon, CalendarIcon, EyeIcon } from '@heroicons/react/24/outline';
-import { Event, EventFormData } from '../types';
-import { useEvents, useCreateEvent, useUpdateEvent, useDeleteEvent } from '../hooks/useEvents';
-import { Modal } from '../components/Modal';
-import { EventForm } from '../components/EventForm';
+import { PlusIcon } from '@heroicons/react/24/outline';
+import { useEffect, useState } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
+import { EventFormModal, EventGrid } from '../features/Events/components';
+import { useEventCrud } from '../features/Events/hooks/useEventCrud';
+import { useEvents } from '../hooks/useEvents';
+import { Event } from '../types';
 
 type EventFilter = 'upcoming' | 'past' | 'all';
 
@@ -14,142 +14,56 @@ export function Events() {
   const [filter, setFilter] = useState<EventFilter>('upcoming');
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [editingEvent, setEditingEvent] = useState<Event | null>(null);
-  
+
   // React Query hooks
-  const queryParams = filter === 'upcoming' ? { upcoming: true } : 
-                     filter === 'past' ? { upcoming: false } : {};
-  const { data, isLoading } = useEvents(queryParams);
-  const createEventMutation = useCreateEvent();
-  const updateEventMutation = useUpdateEvent();
-  const deleteEventMutation = useDeleteEvent();
-  
+  const { data, isLoading } = useEvents(
+    filter === 'upcoming'
+      ? { upcoming: true }
+      : filter === 'past'
+        ? { upcoming: false }
+        : {}
+  );
+
+  // CRUD operations
+  const { handleDeleteEvent, handleFormSubmit, isFormLoading } = useEventCrud();
+
   // Filter events client-side for 'past' filter since backend doesn't handle it
   const allEvents = data?.events || [];
-  const events = filter === 'past' 
-    ? allEvents.filter(event => new Date(event.end_datetime) < new Date())
-    : allEvents;
+  const events =
+    filter === 'past'
+      ? allEvents.filter((event) => new Date(event.end_datetime) < new Date())
+      : allEvents;
   const loading = isLoading;
-
-  const handleCreateEvent = () => {
-    setEditingEvent(null);
-    setIsModalOpen(true);
-  };
-
-  const handleEditEvent = (event: Event) => {
-    setEditingEvent(event);
-    setIsModalOpen(true);
-  };
 
   // Handle edit event from EventDetails page
   useEffect(() => {
     const state = location.state as { editEventId?: number } | null;
     if (state?.editEventId && events.length > 0) {
-      const eventToEdit = events.find(event => event.id === state.editEventId);
+      const eventToEdit = events.find(
+        (event) => event.id === state.editEventId
+      );
       if (eventToEdit) {
-        handleEditEvent(eventToEdit);
+        setEditingEvent(eventToEdit);
+        setIsModalOpen(true);
         // Clear the state to prevent re-triggering
         navigate(location.pathname, { replace: true, state: {} });
       }
     }
-  }, [events, location.state, navigate, location.pathname, handleEditEvent]);
+  }, [events, location.state, navigate, location.pathname]);
 
   const handleViewEvent = (event: Event) => {
     navigate(`/events/${event.id}`);
-  };
-
-  const handleDeleteEvent = async (event: Event) => {
-    if (!confirm(`Are you sure you want to delete "${event.name}"?`)) {
-      return;
-    }
-
-    try {
-      await deleteEventMutation.mutateAsync(event.id);
-    } catch (error) {
-      console.error('Failed to delete event:', error);
-      alert('Failed to delete event. Please try again.');
-    }
-  };
-
-  const handleFormSubmit = async (formData: EventFormData) => {
-    const eventData = {
-      name: formData.name,
-      description: formData.description || undefined,
-      start_datetime: formData.start_datetime,
-      end_datetime: formData.end_datetime,
-      is_public: formData.is_public,
-      max_capacity: formData.max_capacity ? parseInt(formData.max_capacity) : undefined,
-    };
-    
-    try {
-      if (editingEvent) {
-        await updateEventMutation.mutateAsync({
-          id: editingEvent.id,
-          ...eventData
-        });
-        setIsModalOpen(false);
-        setEditingEvent(null);
-      } else {
-        const result = await createEventMutation.mutateAsync(eventData);
-        setIsModalOpen(false);
-        setEditingEvent(null);
-        // Redirect to the newly created event details page
-        navigate(`/events/${result.data.id}`);
-      }
-    } catch (error) {
-      console.error('Failed to save event:', error);
-      alert('Failed to save event. Please try again.');
-    }
-  };
-
-  const formatDateTime = (dateString: string) => {
-    return new Date(dateString).toLocaleString();
-  };
-
-  const getEventStatus = (event: Event) => {
-    const now = new Date();
-    const start = new Date(event.start_datetime);
-    const end = new Date(event.end_datetime);
-    
-    if (now < start) return 'upcoming';
-    if (now >= start && now <= end) return 'ongoing';
-    return 'past';
-  };
-
-  const getStatusBadge = (event: Event) => {
-    const status = getEventStatus(event);
-    const isActive = event.flags & 1;
-    const isPublic = event.flags & 2;
-    
-    return (
-      <div className="flex space-x-1">
-        <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${
-          status === 'upcoming' ? 'bg-blue-100 text-blue-800' :
-          status === 'ongoing' ? 'bg-green-100 text-green-800' :
-          'bg-gray-100 text-gray-800'
-        }`}>
-          {status === 'upcoming' ? 'Upcoming' :
-           status === 'ongoing' ? 'Ongoing' : 'Past'}
-        </span>
-        {isPublic && (
-          <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-purple-100 text-purple-800">
-            Public
-          </span>
-        )}
-        {!isActive && (
-          <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-red-100 text-red-800">
-            Inactive
-          </span>
-        )}
-      </div>
-    );
   };
 
   return (
     <div>
       <div className="flex justify-between items-center mb-6">
         <h1 className="text-3xl font-bold text-gray-900">Events</h1>
-        <button 
-          onClick={handleCreateEvent}
+        <button
+          onClick={() => {
+            setEditingEvent(null);
+            setIsModalOpen(true);
+          }}
           className="bg-blue-600 text-white px-4 py-2 rounded-lg flex items-center hover:bg-blue-700"
         >
           <PlusIcon className="h-5 w-5 mr-2" />
@@ -157,151 +71,36 @@ export function Events() {
         </button>
       </div>
 
-      <div className="bg-white shadow rounded-lg">
-        <div className="p-6 border-b border-gray-200">
-          <div className="flex items-center space-x-4">
-            <button 
-              onClick={() => setFilter('upcoming')}
-              className={`px-4 py-2 rounded-md ${
-                filter === 'upcoming' 
-                  ? 'bg-blue-100 text-blue-700' 
-                  : 'text-gray-600 hover:bg-gray-100'
-              }`}
-            >
-              Upcoming
-            </button>
-            <button 
-              onClick={() => setFilter('past')}
-              className={`px-4 py-2 rounded-md ${
-                filter === 'past' 
-                  ? 'bg-blue-100 text-blue-700' 
-                  : 'text-gray-600 hover:bg-gray-100'
-              }`}
-            >
-              Past
-            </button>
-            <button 
-              onClick={() => setFilter('all')}
-              className={`px-4 py-2 rounded-md ${
-                filter === 'all' 
-                  ? 'bg-blue-100 text-blue-700' 
-                  : 'text-gray-600 hover:bg-gray-100'
-              }`}
-            >
-              All
-            </button>
-          </div>
-        </div>
+      <EventGrid
+        events={events}
+        isLoading={loading}
+        onEdit={(event) => {
+          setEditingEvent(event);
+          setIsModalOpen(true);
+        }}
+        onDelete={handleDeleteEvent}
+        onView={handleViewEvent}
+        isEditPending={false}
+        isDeletePending={false}
+        filter={filter}
+        onFilterChange={setFilter}
+      />
 
-        {loading ? (
-          <div className="p-6 text-center text-gray-500">
-            Loading events...
-          </div>
-        ) : events.length === 0 ? (
-          <div className="p-6">
-            <div className="text-center text-gray-500">
-              <CalendarIcon className="mx-auto h-12 w-12 text-gray-400 mb-4" />
-              <h3 className="text-lg font-medium text-gray-900 mb-2">No events scheduled</h3>
-              <p>Get started by creating your first event.</p>
-            </div>
-          </div>
-        ) : (
-          <div className="overflow-x-auto">
-            <table className="min-w-full divide-y divide-gray-200">
-              <thead className="bg-gray-50">
-                <tr>
-                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                    Event
-                  </th>
-                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                    Date & Time
-                  </th>
-                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                    Capacity
-                  </th>
-                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                    Status
-                  </th>
-                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                    Actions
-                  </th>
-                </tr>
-              </thead>
-              <tbody className="bg-white divide-y divide-gray-200">
-                {events.map((event) => (
-                  <tr key={event.id} className="hover:bg-gray-50">
-                    <td className="px-6 py-4">
-                      <div>
-                        <div className="text-sm font-medium text-gray-900">
-                          {event.name}
-                        </div>
-                        {event.description && (
-                          <div className="text-sm text-gray-500 truncate max-w-xs">
-                            {event.description}
-                          </div>
-                        )}
-                      </div>
-                    </td>
-                    <td className="px-6 py-4 whitespace-nowrap">
-                      <div className="text-sm text-gray-900">
-                        <div>Start: {formatDateTime(event.start_datetime)}</div>
-                        <div>End: {formatDateTime(event.end_datetime)}</div>
-                      </div>
-                    </td>
-                    <td className="px-6 py-4 whitespace-nowrap">
-                      <div className="text-sm text-gray-900">
-                        {event.max_capacity || 'Unlimited'}
-                      </div>
-                    </td>
-                    <td className="px-6 py-4 whitespace-nowrap">
-                      {getStatusBadge(event)}
-                    </td>
-                    <td className="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
-                      <div className="flex space-x-2">
-                        <button
-                          onClick={() => handleViewEvent(event)}
-                          className="text-green-600 hover:text-green-900"
-                          title="View Details"
-                        >
-                          <EyeIcon className="h-4 w-4" />
-                        </button>
-                        <button
-                          onClick={() => handleEditEvent(event)}
-                          className="text-blue-600 hover:text-blue-900"
-                          title="Edit Event"
-                        >
-                          <PencilIcon className="h-4 w-4" />
-                        </button>
-                        <button
-                          onClick={() => handleDeleteEvent(event)}
-                          className="text-red-600 hover:text-red-900"
-                          title="Delete Event"
-                        >
-                          <TrashIcon className="h-4 w-4" />
-                        </button>
-                      </div>
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
-        )}
-      </div>
-
-      <Modal
+      <EventFormModal
         isOpen={isModalOpen}
-        onClose={() => setIsModalOpen(false)}
-        title={editingEvent ? 'Edit Event' : 'Create New Event'}
-      >
-        <EventForm
-          event={editingEvent || undefined}
-          onSubmit={handleFormSubmit}
-          onCancel={() => setIsModalOpen(false)}
-          isLoading={createEventMutation.isPending || updateEventMutation.isPending}
-        />
-      </Modal>
+        editingEvent={editingEvent}
+        onSubmit={async (formData: any) => {
+          await handleFormSubmit(formData, editingEvent, () => {
+            setIsModalOpen(false);
+            setEditingEvent(null);
+          });
+        }}
+        onClose={() => {
+          setIsModalOpen(false);
+          setEditingEvent(null);
+        }}
+        isLoading={isFormLoading}
+      />
     </div>
   );
 }
-

--- a/administration/client/src/pages/MemberDetails.tsx
+++ b/administration/client/src/pages/MemberDetails.tsx
@@ -1,38 +1,34 @@
 import {
   ArrowLeftIcon,
-  ChatBubbleLeftIcon,
   ClockIcon,
   EnvelopeIcon,
   PencilIcon,
   TrashIcon,
 } from '@heroicons/react/24/outline';
-import { useMutation } from '@tanstack/react-query';
 import { useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
-import { MemberForm } from '../components/MemberForm';
 import { Modal } from '../components/Modal';
+import {
+  ApplicationNotes,
+  AuditHistory,
+  EditMemberForm,
+  EmailModal,
+  InfoCards,
+  LoadingStates,
+} from '../features/MemberDetails/components';
 import { useAuditLog } from '../hooks/useAudit';
 import {
   useDeleteMember,
   useMember,
   useUpdateMember,
 } from '../hooks/useMembers';
-import { api } from '../lib/api';
 import { MemberFormData } from '../types';
-import {
-  getAccessLevelColor,
-  getAccessLevelName,
-} from '../utils/authorization';
 
 export function MemberDetails() {
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
   const [isEditModalOpen, setIsEditModalOpen] = useState(false);
   const [isEmailModalOpen, setIsEmailModalOpen] = useState(false);
-  const [noteContent, setNoteContent] = useState('');
-  const [selectedTemplate, setSelectedTemplate] = useState('');
-  const [emailSubject, setEmailSubject] = useState('');
-  const [emailBody, setEmailBody] = useState('');
 
   const memberId = parseInt(id || '0', 10);
   const { data: member, isLoading, error } = useMember(memberId, !!id);
@@ -43,43 +39,6 @@ export function MemberDetails() {
   } = useAuditLog('member', memberId, !!id);
   const updateMember = useUpdateMember();
   const deleteMember = useDeleteMember();
-
-  const emailTemplates = [
-    {
-      id: 'welcome',
-      name: 'Welcome Email',
-      subject: 'Welcome to Our Community!',
-      body: "Hi {{first_name}},\n\nWelcome to our community! We're excited to have you join us.\n\nLorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.\n\nBest regards,\nThe Team",
-    },
-    {
-      id: 'reminder',
-      name: 'Event Reminder',
-      subject: 'Upcoming Event Reminder',
-      body: 'Hello {{preferred_name || first_name}},\n\nThis is a friendly reminder about our upcoming event.\n\nLorem ipsum dolor sit amet, consectetur adipiscing elit. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris.\n\nSee you there!\nEvent Team',
-    },
-    {
-      id: 'follow_up',
-      name: 'Follow-up',
-      subject: 'Following up with you',
-      body: 'Dear {{first_name}},\n\nI wanted to follow up on our recent conversation.\n\nLorem ipsum dolor sit amet, consectetur adipiscing elit. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore.\n\nPlease let me know if you have any questions.\n\nBest,\nAdmin Team',
-    },
-  ];
-
-  const addNoteMutation = useMutation({
-    mutationFn: async ({ content }: { content: string }) => {
-      const response = await api.post(`/members/${memberId}/notes`, {
-        content,
-        tags: [],
-      });
-      return response.data;
-    },
-    onSuccess: () => {
-      // Refetch audit log to show the new note
-      refetchAuditLog();
-      // Reset form
-      setNoteContent('');
-    },
-  });
 
   const handleUpdateMember = async (formData: MemberFormData) => {
     try {
@@ -114,22 +73,8 @@ export function MemberDetails() {
     }
   };
 
-  const handleTemplateSelect = (templateId: string) => {
-    setSelectedTemplate(templateId);
-    if (templateId) {
-      const template = emailTemplates.find((t) => t.id === templateId);
-      if (template) {
-        setEmailSubject(template.subject);
-        setEmailBody(template.body);
-      }
-    } else {
-      setEmailSubject('');
-      setEmailBody('');
-    }
-  };
-
-  const handleSendEmail = async () => {
-    if (!member || !emailSubject.trim() || !emailBody.trim()) {
+  const handleSendEmail = async (subject: string, body: string) => {
+    if (!member || !subject.trim() || !body.trim()) {
       alert('Please fill in both subject and body fields.');
       return;
     }
@@ -137,118 +82,24 @@ export function MemberDetails() {
     // In a real implementation, this would call an API to send the email
     // For now, we'll just show an alert
     alert(
-      `Email would be sent to ${member.email}\n\nSubject: ${emailSubject}\n\nBody: ${emailBody.substring(0, 100)}...\n\nThis is a placeholder implementation.`
+      `Email would be sent to ${member.email}\n\nSubject: ${subject}\n\nBody: ${body.substring(0, 100)}...\n\nThis is a placeholder implementation.`
     );
     setIsEmailModalOpen(false);
-    setSelectedTemplate('');
-    setEmailSubject('');
-    setEmailBody('');
   };
 
-  const handleEmailModalClose = () => {
-    setIsEmailModalOpen(false);
-    setSelectedTemplate('');
-    setEmailSubject('');
-    setEmailBody('');
+  const handleNoteAdded = () => {
+    refetchAuditLog();
   };
 
-  const handleSubmitNote = async (e: React.FormEvent) => {
-    e.preventDefault();
-
-    if (!noteContent.trim()) {
-      return;
-    }
-
-    try {
-      await addNoteMutation.mutateAsync({ content: noteContent.trim() });
-    } catch (error) {
-      console.error('Failed to add note:', error);
-      alert('Failed to add note. Please try again.');
-    }
-  };
-
-  const getDisplayName = (member: any) => {
-    return member.preferred_name
-      ? `${member.preferred_name} (${member.first_name}) ${member.last_name}`
-      : `${member.first_name} ${member.last_name}`;
-  };
-
-  const getStatusBadge = (member: any) => {
-    const isActive = member.flags & 1;
-    const isProfessional = member.flags & 2;
-
-    return (
-      <div className="flex flex-wrap gap-1">
-        <span
-          className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${
-            isActive ? 'bg-green-100 text-green-800' : 'bg-red-100 text-red-800'
-          }`}
-        >
-          {isActive ? 'Active' : 'Inactive'}
-        </span>
-        {isProfessional && (
-          <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-blue-100 text-blue-800">
-            Professional
-          </span>
-        )}
-        <span
-          className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${getAccessLevelColor(
-            member.access_level || 1
-          )}`}
-        >
-          {getAccessLevelName(member.access_level || 1)}
-        </span>
-      </div>
-    );
-  };
-
-  if (isLoading) {
-    return (
-      <div className="flex items-center justify-center min-h-96">
-        <div className="text-gray-500">Loading member details...</div>
-      </div>
-    );
+  // Handle loading and error states
+  if (isLoading || error || !member) {
+    return <LoadingStates isLoading={isLoading} error={error} />;
   }
 
-  if (error || !member) {
-    // Check if it's a 403 Unauthorized error
-    const is403Error =
-      error &&
-      typeof error === 'object' &&
-      'response' in error &&
-      (error as any).response?.status === 403;
-
-    return (
-      <div className="text-center py-12">
-        <div className="text-red-600 mb-4">
-          {is403Error
-            ? "You don't have permission to access this member's details"
-            : 'Failed to load member details'}
-        </div>
-        <div className="space-x-4">
-          <button
-            onClick={() => navigate(is403Error ? '/dashboard' : '/members')}
-            className="bg-blue-600 text-white px-4 py-2 rounded-md hover:bg-blue-700"
-            data-testid="back-to-members-btn"
-          >
-            {is403Error ? 'Go to Dashboard' : 'Back to Members'}
-          </button>
-          {!is403Error && (
-            <button
-              onClick={() => window.location.reload()}
-              className="bg-gray-600 text-white px-4 py-2 rounded-md hover:bg-gray-700"
-            >
-              Retry
-            </button>
-          )}
-        </div>
-      </div>
-    );
-  }
+  const displayName = `${member.first_name} ${member.preferred_name ? `(${member.preferred_name}) ` : ''}${member.last_name}`;
 
   return (
     <div className="max-w-4xl mx-auto">
-      {/* Header */}
       <div className="flex items-center justify-between mb-6">
         <div className="flex items-center space-x-4">
           <button
@@ -263,7 +114,7 @@ export function MemberDetails() {
               className="text-3xl font-bold text-gray-900"
               data-testid="member-name-heading"
             >
-              {getDisplayName(member)}
+              {displayName}
             </h1>
             <p className="text-gray-600">{member.email}</p>
           </div>
@@ -296,224 +147,19 @@ export function MemberDetails() {
         </div>
       </div>
 
-      {/* Member Details */}
-      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
-        {/* Basic Information */}
-        <div className="bg-white shadow rounded-lg p-6">
-          <h2 className="text-lg font-semibold text-gray-900 mb-4">
-            Basic Information
-          </h2>
-          <dl className="space-y-3">
-            <div>
-              <dt className="text-sm font-medium text-gray-500">Full Name</dt>
-              <dd className="text-sm text-gray-900">
-                {member.first_name} {member.last_name}
-              </dd>
-            </div>
-            {member.preferred_name && (
-              <div>
-                <dt className="text-sm font-medium text-gray-500">
-                  Preferred Name
-                </dt>
-                <dd className="text-sm text-gray-900">
-                  {member.preferred_name}
-                </dd>
-              </div>
-            )}
-            <div>
-              <dt className="text-sm font-medium text-gray-500">Email</dt>
-              <dd className="text-sm text-gray-900">{member.email}</dd>
-            </div>
-            {member.pronouns && (
-              <div>
-                <dt className="text-sm font-medium text-gray-500">Pronouns</dt>
-                <dd className="text-sm text-gray-900">{member.pronouns}</dd>
-              </div>
-            )}
-            <div>
-              <dt className="text-sm font-medium text-gray-500">Status</dt>
-              <dd className="text-sm text-gray-900">
-                {getStatusBadge(member)}
-              </dd>
-            </div>
-            <div>
-              <dt className="text-sm font-medium text-gray-500">
-                Member Since
-              </dt>
-              <dd className="text-sm text-gray-900">
-                {new Date(member.created_at).toLocaleDateString()}
-              </dd>
-            </div>
-          </dl>
-        </div>
+      <InfoCards member={member} />
 
-        {/* Additional Information */}
-        <div className="bg-white shadow rounded-lg p-6">
-          <h2 className="text-lg font-semibold text-gray-900 mb-4">
-            Additional Information
-          </h2>
-          <dl className="space-y-3">
-            {member.sponsor_notes && (
-              <div>
-                <dt className="text-sm font-medium text-gray-500">
-                  Sponsor Notes
-                </dt>
-                <dd className="text-sm text-gray-900 whitespace-pre-wrap">
-                  {member.sponsor_notes}
-                </dd>
-              </div>
-            )}
-            <div>
-              <dt className="text-sm font-medium text-gray-500">
-                Last Updated
-              </dt>
-              <dd className="text-sm text-gray-900">
-                {new Date(member.updated_at).toLocaleDateString()}
-              </dd>
-            </div>
-          </dl>
-        </div>
-      </div>
+      <ApplicationNotes memberId={memberId} onNoteAdded={handleNoteAdded} />
 
-      {/* Notes Section */}
-      <div className="mt-6 bg-white shadow rounded-lg p-6">
-        <h2 className="text-lg font-semibold text-gray-900 mb-3 flex items-center">
-          <ChatBubbleLeftIcon className="h-5 w-5 mr-2" />
-          Notes
-        </h2>
-
-        <form onSubmit={handleSubmitNote} className="mb-4">
-          <div className="flex gap-3">
-            <textarea
-              id="noteContent"
-              rows={2}
-              value={noteContent}
-              onChange={(e) => setNoteContent(e.target.value)}
-              className="flex-1 px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500 text-sm"
-              placeholder="Add a note about this member..."
-              data-testid="member-note-textarea"
-              disabled={addNoteMutation.isPending}
-            />
-            <button
-              type="submit"
-              disabled={!noteContent.trim() || addNoteMutation.isPending}
-              className="px-4 py-2 bg-purple-600 text-white rounded-md hover:bg-purple-700 disabled:opacity-50 disabled:cursor-not-allowed text-sm whitespace-nowrap self-start"
-            >
-              {addNoteMutation.isPending ? 'Adding...' : 'Add Note'}
-            </button>
-          </div>
-        </form>
-      </div>
-
-      {/* Activity History */}
       <div className="mt-6 bg-white shadow rounded-lg p-6">
         <h2 className="text-lg font-semibold text-gray-900 mb-4 flex items-center">
           <ClockIcon className="h-5 w-5 mr-2" />
-          Activity History
+          Audit History
         </h2>
-
         {auditLoading ? (
-          <div className="text-gray-500 text-sm">
-            Loading activity history...
-          </div>
-        ) : !auditLog || auditLog.length === 0 ? (
-          <div className="text-gray-500 text-sm">No activity recorded yet.</div>
+          <div className="text-gray-500 text-sm">Loading audit history...</div>
         ) : (
-          <div className="space-y-4">
-            {auditLog
-              .filter((entry) => entry.action !== 'view')
-              .map((entry) => (
-                <div
-                  key={entry.id}
-                  className="border-l-4 border-blue-200 pl-4 py-2"
-                >
-                  <div className="flex items-center justify-between">
-                    <div className="flex items-center space-x-2">
-                      <span
-                        className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${
-                          entry.action === 'create'
-                            ? 'bg-green-100 text-green-800'
-                            : entry.action === 'update'
-                              ? 'bg-yellow-100 text-yellow-800'
-                              : entry.action === 'delete'
-                                ? 'bg-red-100 text-red-800'
-                                : entry.action === 'view'
-                                  ? 'bg-blue-100 text-blue-800'
-                                  : entry.action === 'note'
-                                    ? 'bg-purple-100 text-purple-800'
-                                    : 'bg-gray-100 text-gray-800'
-                        }`}
-                      >
-                        {entry.action.charAt(0).toUpperCase() +
-                          entry.action.slice(1)}
-                      </span>
-                      <span className="text-sm text-gray-600">
-                        {new Date(entry.created_at).toLocaleString()}
-                      </span>
-                    </div>
-                    <span className="text-xs text-gray-400">
-                      Session:{' '}
-                      {(entry.user_session_id || 'unknown').slice(0, 8)}... |
-                      IP: {entry.user_ip}
-                    </span>
-                  </div>
-
-                  {entry.action === 'update' &&
-                    entry.oldValues &&
-                    entry.newValues && (
-                      <div className="mt-2 text-sm">
-                        <div className="text-gray-600 mb-1">Changes made:</div>
-                        <div className="bg-gray-50 rounded p-2 space-y-1">
-                          {Object.keys(entry.newValues).map((key) => {
-                            const oldValue = entry.oldValues?.[key];
-                            const newValue = entry.newValues?.[key];
-
-                            if (
-                              oldValue !== newValue &&
-                              key !== 'id' &&
-                              key !== 'updated_at'
-                            ) {
-                              return (
-                                <div key={key} className="text-xs">
-                                  <span className="font-medium capitalize">
-                                    {key.replace(/_/g, ' ')}:
-                                  </span>
-                                  <span className="text-red-600 line-through ml-1">
-                                    {String(oldValue || '(empty)')}
-                                  </span>
-                                  <span className="mx-1">→</span>
-                                  <span className="text-green-600">
-                                    {String(newValue || '(empty)')}
-                                  </span>
-                                </div>
-                              );
-                            }
-                            return null;
-                          })}
-                        </div>
-                      </div>
-                    )}
-
-                  {entry.action === 'create' && entry.newValues && (
-                    <div className="mt-2 text-sm">
-                      <div className="text-gray-600">
-                        Member created with initial data
-                      </div>
-                    </div>
-                  )}
-
-                  {entry.action === 'note' && entry.metadata && (
-                    <div className="mt-2 text-sm">
-                      <div className="bg-purple-50 rounded p-3 border-l-2 border-purple-200">
-                        <div className="text-gray-800 whitespace-pre-wrap">
-                          {entry.metadata.content}
-                        </div>
-                      </div>
-                    </div>
-                  )}
-                </div>
-              ))}
-          </div>
+          <AuditHistory auditLog={auditLog} />
         )}
       </div>
 
@@ -523,7 +169,7 @@ export function MemberDetails() {
         onClose={() => setIsEditModalOpen(false)}
         title="Edit Member"
       >
-        <MemberForm
+        <EditMemberForm
           member={member}
           onSubmit={handleUpdateMember}
           onCancel={() => setIsEditModalOpen(false)}
@@ -531,101 +177,12 @@ export function MemberDetails() {
         />
       </Modal>
 
-      {/* Email Modal */}
-      <Modal
+      <EmailModal
         isOpen={isEmailModalOpen}
-        onClose={handleEmailModalClose}
-        title="Send Email"
-      >
-        <div className="space-y-4">
-          <div>
-            <p className="text-sm text-gray-600 mb-3">
-              Send email to:{' '}
-              <span className="font-medium">{member?.email}</span>
-            </p>
-            <label
-              htmlFor="emailTemplate"
-              className="block text-sm font-medium text-gray-700 mb-2"
-            >
-              Choose Template (Optional)
-            </label>
-            <select
-              id="emailTemplate"
-              value={selectedTemplate}
-              onChange={(e) => handleTemplateSelect(e.target.value)}
-              className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500"
-            >
-              <option value="">Write your own email...</option>
-              {emailTemplates.map((template) => (
-                <option key={template.id} value={template.id}>
-                  {template.name}
-                </option>
-              ))}
-            </select>
-          </div>
-
-          <div>
-            <label
-              htmlFor="emailSubject"
-              className="block text-sm font-medium text-gray-700 mb-2"
-            >
-              Subject
-            </label>
-            <input
-              type="text"
-              id="emailSubject"
-              value={emailSubject}
-              onChange={(e) => setEmailSubject(e.target.value)}
-              className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500"
-              placeholder="Enter email subject..."
-            />
-          </div>
-
-          <div>
-            <label
-              htmlFor="emailBody"
-              className="block text-sm font-medium text-gray-700 mb-2"
-            >
-              Message
-            </label>
-            <textarea
-              id="emailBody"
-              rows={8}
-              value={emailBody}
-              onChange={(e) => setEmailBody(e.target.value)}
-              className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500"
-              placeholder="Write your email message here..."
-            />
-          </div>
-
-          <div className="bg-blue-50 p-3 rounded-md">
-            <h4 className="font-medium text-blue-900 mb-1">
-              Available Variables:
-            </h4>
-            <p className="text-sm text-blue-700">
-              You can use these placeholders: <code>{'{{first_name}}'}</code>,{' '}
-              <code>{'{{last_name}}'}</code>,{' '}
-              <code>{'{{preferred_name}}'}</code>, <code>{'{{email}}'}</code>
-            </p>
-          </div>
-
-          <div className="flex justify-end space-x-3">
-            <button
-              onClick={handleEmailModalClose}
-              className="px-4 py-2 text-gray-700 bg-gray-200 rounded-md hover:bg-gray-300"
-            >
-              Cancel
-            </button>
-            <button
-              onClick={handleSendEmail}
-              disabled={!emailSubject.trim() || !emailBody.trim()}
-              className="px-4 py-2 bg-green-600 text-white rounded-md hover:bg-green-700 disabled:opacity-50 disabled:cursor-not-allowed"
-            >
-              Send Email
-            </button>
-          </div>
-        </div>
-      </Modal>
+        onClose={() => setIsEmailModalOpen(false)}
+        member={member}
+        onSendEmail={handleSendEmail}
+      />
     </div>
   );
 }

--- a/administration/client/src/pages/Members.tsx
+++ b/administration/client/src/pages/Members.tsx
@@ -7,8 +7,8 @@ import {
 import { useState } from 'react';
 import { Link } from 'react-router-dom';
 import { CsvImport } from '../components/CsvImport';
-import { MemberForm } from '../components/MemberForm';
 import { Modal } from '../components/Modal';
+import { EditMemberForm } from '../features/MemberDetails/components/EditMemberForm';
 import {
   useCreateMember,
   useDeleteMember,
@@ -352,7 +352,7 @@ export function Members() {
         }}
         title={editingMember ? 'Edit Member' : 'Add New Member'}
       >
-        <MemberForm
+        <EditMemberForm
           member={editingMember || undefined}
           onSubmit={handleFormSubmit}
           onCancel={() => {


### PR DESCRIPTION
This adds a `features/` folder, which contains a lot of the core logic for each page. For example:

```
  features/EventDetails/
  ├── components/
  │   ├── EventHeader.tsx
  │   ├── EventTabs.tsx
  │   ├── EventOverview.tsx
  │   ├── EventMarketing.tsx
  │   ├── EventAttendance.tsx
  │   └── index.ts
  └── hooks/
      ├── useEventCrud.ts
      ├── useEventDetails.ts
      └── useEventMarketing.ts
  pages/
  └── EventDetails.tsx
```

This adds
- features/EventDetails/
- features/Events/
- features/MemberDetails/
- features/Members/

This point of abstraction helps us better isolate code, so we can think about it in terms of smaller units of behavior. The routing logic, layout, and potentially e.g. auth and authz guarantees etc, can live separately from the actual business logic.